### PR TITLE
update sync controller for mission CRD

### DIFF
--- a/edge/pkg/metamanager/dao/meta.go
+++ b/edge/pkg/metamanager/dao/meta.go
@@ -112,6 +112,17 @@ func QueryAllMetaByType(dataType string) (*[]Meta, error) {
 	return meta, nil
 }
 
+// QueryAllMeta return all meta, if no error, Meta not null
+func QueryAll() (*[]Meta, error) {
+	meta := new([]Meta)
+	_, err := dbm.DBAccess.QueryTable(MetaTableName).All(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return meta, nil
+}
+
 // DeleteMetaByKey delete the meta of a give type
 // Use cautiously only in debug mode.
 func DeleteMetaByType(dataType string) error {

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -149,7 +149,13 @@ func resourceUnchanged(resType string, resKey string, content []byte) bool {
 }
 
 func (m *metaManager) processInsert(message model.Message) {
-	var err error
+	resKey, resType, _ := parseResource(message.GetResource())
+	dbRecord, err := dao.QueryMeta("key", resKey)
+	if err == nil && len(*dbRecord) > 0 {
+		m.processUpdate(message)
+		return
+	}
+
 	var content []byte
 	switch message.GetContent().(type) {
 	case []uint8:
@@ -163,7 +169,7 @@ func (m *metaManager) processInsert(message model.Message) {
 		}
 	}
 	imitator.DefaultV2Client.Inject(message)
-	resKey, resType, _ := parseResource(message.GetResource())
+
 	switch resType {
 	case constants.ResourceTypeServiceList:
 		var svcList []v1.Service
@@ -225,6 +231,7 @@ func (m *metaManager) processInsert(message model.Message) {
 }
 
 func (m *metaManager) processUpdate(message model.Message) {
+
 	var err error
 	var content []byte
 	switch message.GetContent().(type) {

--- a/tests/edgecluster/data/missions/updated-deployment-to-all.yaml
+++ b/tests/edgecluster/data/missions/updated-deployment-to-all.yaml
@@ -1,0 +1,28 @@
+apiVersion: edgeclusters.kubeedge.io/v1
+kind: Mission
+metadata:
+  name: deployment-to-all
+spec:
+  content: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: deployment-to-all
+      namespace: default
+      labels:
+        app: nginx
+    spec:
+      replicas: 10
+      selector:
+        matchLabels:
+          app: nginx
+      template:
+        metadata:
+          labels:
+            app: nginx
+        spec:
+          containers:
+          - name: nginx
+            image: nginx:1.7.9
+            ports:
+            - containerPort: 80


### PR DESCRIPTION
This PR fixes the sync controller to make it work with the CRD of missions.edgeclusters.kubeedge.io.

Before this change, the sync controller kept complaining unable to get the object of missions deployed and it did not pick up the change in mission objects.

### Verficiation
With this PR, the following verfication succeeded:
1. Start a cloudcore and an edgecore in edgecluster mode.
2. in the cloud cluster, deploy a mission.
3. Turn off the cloudcore and edgecore.
4. Update the mission ( in the test, I updated the deployment replica number in the mission content from 3 to 10).
5. Restart the cloudcore and the edgecore in edgecluster mode.
6. Verified: the mission in the edge cluster picked up the updated version of the mission, the deployment deployed by the missions has a replica number of 10 now.