### PR TITLE
rename edgecluster module to clusterd module

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -15,9 +15,9 @@ import (
 	"github.com/kubeedge/beehive/pkg/core"
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
+	"github.com/kubeedge/kubeedge/edge/pkg/clusterd"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/dbm"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin"
-	"github.com/kubeedge/kubeedge/edge/pkg/edgecluster"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgestream"
@@ -92,11 +92,11 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 					config.Modules.Edged.NodeIP = localIP
 				}
 			} else {
-				if config.Modules.EdgeCluster.NodeIP == "" {
-					config.Modules.EdgeCluster.NodeIP = localIP
+				if config.Modules.Clusterd.NodeIP == "" {
+					config.Modules.Clusterd.NodeIP = localIP
 				}
-				if config.Modules.EdgeCluster.Name == "" {
-					config.Modules.EdgeCluster.Name = hostnameOverride
+				if config.Modules.Clusterd.Name == "" {
+					config.Modules.Clusterd.Name = hostnameOverride
 				}
 			}
 
@@ -171,8 +171,8 @@ func registerModules(c *v1alpha1.EdgeCoreConfig, edgeClusterMode bool) {
 	metamanager.Register(c.Modules.MetaManager, edgeClusterMode)
 
 	if edgeClusterMode {
-		edgecluster.Register(c.Modules.EdgeCluster)
-		edgestream.Register(c.Modules.EdgeStream, c.Modules.EdgeCluster.Name, c.Modules.EdgeCluster.NodeIP)
+		clusterd.Register(c.Modules.Clusterd)
+		edgestream.Register(c.Modules.EdgeStream, c.Modules.Clusterd.Name, c.Modules.Clusterd.NodeIP)
 	} else {
 		devicetwin.Register(c.Modules.DeviceTwin, c.Modules.Edged.HostnameOverride)
 		edged.Register(c.Modules.Edged)

--- a/edge/pkg/clusterd/clusterd.go
+++ b/edge/pkg/clusterd/clusterd.go
@@ -52,7 +52,7 @@ const (
 	EdgeController     = "edgecontroller"
 )
 
-// edgeCluster is the main edgeCluster implementation.
+// clusterd is the implementation to manage an edge cluser.
 type clusterd struct {
 	name                  string
 	missionManager        *MissionManager
@@ -67,12 +67,12 @@ type clusterd struct {
 	kubeconfig            string
 }
 
-// Register register edgeCluster
+// Register register clusterd module
 func Register(e *v1alpha1.Clusterd) {
 	config.InitConfigure(e)
 	clusterd, err := newClusterd(e.Enable)
 	if err != nil {
-		klog.Errorf("init new edgeCluster error, %v", err)
+		klog.Errorf("init new clusterd error, %v", err)
 		os.Exit(1)
 		return
 	}
@@ -93,7 +93,7 @@ func (e *clusterd) Enable() bool {
 }
 
 func (e *clusterd) Start() {
-	klog.Info("Starting edgeCluster...")
+	klog.Info("Starting clusterd...")
 
 	go utilwait.Until(e.syncEdgeClusterStatus, e.statusUpdateInterval, utilwait.NeverStop)
 

--- a/edge/pkg/clusterd/clusterd.go
+++ b/edge/pkg/clusterd/clusterd.go
@@ -17,11 +17,11 @@ limitations under the License.
 KubeEdge Authors: To create mini-kubelet for edge deployment scenario,
 This file is derived from K8S Kubelet code with reduced set of methods
 Changes done are
-1. package edgecluster got some functions from "k8s.io/kubernetes/pkg/kubelet/kubelet.go"
+1. package clusterd got some functions from "k8s.io/kubernetes/pkg/kubelet/kubelet.go"
 and made some variant
 */
 
-package edgecluster
+package clusterd
 
 import (
 	"encoding/json"
@@ -36,8 +36,8 @@ import (
 	"github.com/kubeedge/beehive/pkg/core/model"
 	edgeclustersv1 "github.com/kubeedge/kubeedge/cloud/pkg/apis/edgeclusters/v1"
 	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/edge/pkg/clusterd/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
-	"github.com/kubeedge/kubeedge/edge/pkg/edgecluster/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
@@ -53,7 +53,7 @@ const (
 )
 
 // edgeCluster is the main edgeCluster implementation.
-type edgeCluster struct {
+type clusterd struct {
 	name                  string
 	missionManager        *MissionManager
 	uid                   types.UID
@@ -68,31 +68,31 @@ type edgeCluster struct {
 }
 
 // Register register edgeCluster
-func Register(e *v1alpha1.EdgeCluster) {
+func Register(e *v1alpha1.Clusterd) {
 	config.InitConfigure(e)
-	edgeCluster, err := newEdgeCluster(e.Enable)
+	clusterd, err := newClusterd(e.Enable)
 	if err != nil {
 		klog.Errorf("init new edgeCluster error, %v", err)
 		os.Exit(1)
 		return
 	}
-	core.Register(edgeCluster)
+	core.Register(clusterd)
 }
 
-func (e *edgeCluster) Name() string {
-	return modules.EdgeClusterModuleName
+func (e *clusterd) Name() string {
+	return modules.ClusterdModuleName
 }
 
-func (e *edgeCluster) Group() string {
-	return modules.EdgeClusterGroup
+func (e *clusterd) Group() string {
+	return modules.ClusterdGroup
 }
 
 //Enable indicates whether this module is enabled
-func (e *edgeCluster) Enable() bool {
+func (e *clusterd) Enable() bool {
 	return e.enable
 }
 
-func (e *edgeCluster) Start() {
+func (e *clusterd) Start() {
 	klog.Info("Starting edgeCluster...")
 
 	go utilwait.Until(e.syncEdgeClusterStatus, e.statusUpdateInterval, utilwait.NeverStop)
@@ -103,9 +103,9 @@ func (e *edgeCluster) Start() {
 	return
 }
 
-//newEdgeCluster creates new edgeCluster object and initialises it
-func newEdgeCluster(enable bool) (*edgeCluster, error) {
-	missionManager := NewMissionManager(&config.Config.EdgeCluster)
+//newClusterd creates new Clusterd object and initialises it
+func newClusterd(enable bool) (*clusterd, error) {
+	missionManager := NewMissionManager(&config.Config.Clusterd)
 	metaClient := client.New()
 
 	if !FileExists(config.Config.Kubeconfig) {
@@ -119,13 +119,13 @@ func newEdgeCluster(enable bool) (*edgeCluster, error) {
 	basedir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 	kubectlPath := filepath.Join(basedir, DistroToKubectl[config.Config.KubeDistro])
 
-	ec := &edgeCluster{
+	ec := &clusterd{
 		name:                 config.Config.Name,
 		namespace:            config.Config.RegisterNamespace,
 		missionManager:       missionManager,
 		enable:               enable,
 		uid:                  types.UID("76246eec-1dc7-4bcf-89b4-686dbc3b4234"),
-		statusUpdateInterval: time.Duration(config.Config.EdgeCluster.StatusUpdateInterval) * time.Second,
+		statusUpdateInterval: time.Duration(config.Config.Clusterd.StatusUpdateInterval) * time.Second,
 		metaClient:           metaClient,
 		kubeDistro:           config.Config.KubeDistro,
 		kubeconfig:           config.Config.Kubeconfig,
@@ -134,7 +134,7 @@ func newEdgeCluster(enable bool) (*edgeCluster, error) {
 	return ec, nil
 }
 
-func (e *edgeCluster) syncCloud() {
+func (e *clusterd) syncCloud() {
 	time.Sleep(10 * time.Second)
 
 	//when starting, send msg to metamanager once to get existing missions
@@ -144,7 +144,7 @@ func (e *edgeCluster) syncCloud() {
 	for {
 		select {
 		case <-beehiveContext.Done():
-			klog.Warning("EdgeCluster Sync stop")
+			klog.Warning("Clusterd Sync stop")
 			return
 		default:
 		}
@@ -202,7 +202,7 @@ func (e *edgeCluster) syncCloud() {
 	}
 }
 
-func (e *edgeCluster) handleMissionList(content []byte) (err error) {
+func (e *clusterd) handleMissionList(content []byte) (err error) {
 	if e.missionManager == nil {
 		return fmt.Errorf("mission manager is not initialized.")
 	}
@@ -226,7 +226,7 @@ func (e *edgeCluster) handleMissionList(content []byte) (err error) {
 	return e.missionManager.AlignMissionList(missionList)
 }
 
-func (e *edgeCluster) handleMission(op string, content []byte) (err error) {
+func (e *clusterd) handleMission(op string, content []byte) (err error) {
 	if e.missionManager == nil {
 		return fmt.Errorf("mission manager is not initialized.")
 	}

--- a/edge/pkg/clusterd/config/config.go
+++ b/edge/pkg/clusterd/config/config.go
@@ -10,13 +10,13 @@ var Config Configure
 var once sync.Once
 
 type Configure struct {
-	v1alpha1.EdgeCluster
+	v1alpha1.Clusterd
 }
 
-func InitConfigure(e *v1alpha1.EdgeCluster) {
+func InitConfigure(e *v1alpha1.Clusterd) {
 	once.Do(func() {
 		Config = Configure{
-			EdgeCluster: *e,
+			Clusterd: *e,
 		}
 	})
 }

--- a/edge/pkg/clusterd/mission_manager.go
+++ b/edge/pkg/clusterd/mission_manager.go
@@ -49,17 +49,17 @@ type MissionManager struct {
 }
 
 //NewMissionManager creates new mission manager object
-func NewMissionManager(edgeClusterConfig *v1alpha1.Clusterd) *MissionManager {
+func NewMissionManager(clusterdConfig *v1alpha1.Clusterd) *MissionManager {
 
 	// No need to check the config, as it was checked during the registration
 	basedir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 
 	return &MissionManager{
-		ClusterName:    edgeClusterConfig.Name,
-		ClusterLabels:  edgeClusterConfig.Labels,
-		KubeDistro:     edgeClusterConfig.KubeDistro,
-		KubeconfigFile: edgeClusterConfig.Kubeconfig,
-		KubectlCli:     filepath.Join(basedir, DistroToKubectl[edgeClusterConfig.KubeDistro]),
+		ClusterName:    clusterdConfig.Name,
+		ClusterLabels:  clusterdConfig.Labels,
+		KubeDistro:     clusterdConfig.KubeDistro,
+		KubeconfigFile: clusterdConfig.Kubeconfig,
+		KubectlCli:     filepath.Join(basedir, DistroToKubectl[clusterdConfig.KubeDistro]),
 		MissionMatch:   map[string]bool{},
 	}
 }

--- a/edge/pkg/clusterd/mission_manager.go
+++ b/edge/pkg/clusterd/mission_manager.go
@@ -12,7 +12,7 @@ limitations under the License.
 
 */
 
-package edgecluster
+package clusterd
 
 import (
 	"encoding/json"
@@ -49,7 +49,7 @@ type MissionManager struct {
 }
 
 //NewMissionManager creates new mission manager object
-func NewMissionManager(edgeClusterConfig *v1alpha1.EdgeCluster) *MissionManager {
+func NewMissionManager(edgeClusterConfig *v1alpha1.Clusterd) *MissionManager {
 
 	// No need to check the config, as it was checked during the registration
 	basedir, _ := filepath.Abs(filepath.Dir(os.Args[0]))

--- a/edge/pkg/clusterd/util.go
+++ b/edge/pkg/clusterd/util.go
@@ -12,7 +12,7 @@ limitations under the License.
 
 */
 
-package edgecluster
+package clusterd
 
 import (
 	"context"

--- a/edge/pkg/common/modules/group.go
+++ b/edge/pkg/common/modules/group.go
@@ -17,6 +17,6 @@ const (
 	MeshGroup = "mesh"
 	// StreamGroup group
 	StreamGroup = "edgestream"
-	// EdgeCluster Group
+	// Clusterd Group
 	ClusterdGroup = "clusterd"
 )

--- a/edge/pkg/common/modules/group.go
+++ b/edge/pkg/common/modules/group.go
@@ -18,5 +18,5 @@ const (
 	// StreamGroup group
 	StreamGroup = "edgestream"
 	// EdgeCluster Group
-	EdgeClusterGroup = "edgecluster"
+	ClusterdGroup = "clusterd"
 )

--- a/edge/pkg/common/modules/names.go
+++ b/edge/pkg/common/modules/names.go
@@ -13,6 +13,6 @@ const (
 	EdgeStreamModuleName = "edgestream"
 	// DeviceTwinModuleName name
 	DeviceTwinModuleName = "twin"
-	// EdgeClusterModuleName name
-	EdgeClusterModuleName = "edgecluster"
+	// ClusterdModuleName name
+	ClusterdModuleName = "clusterd"
 )

--- a/edge/pkg/metamanager/client/edgeclusterstatus.go
+++ b/edge/pkg/metamanager/client/edgeclusterstatus.go
@@ -40,7 +40,7 @@ func (c *edgeClusterStatus) Create(ns *edgeapi.EdgeClusterStatusRequest) (*edgea
 
 func (c *edgeClusterStatus) Update(rsName string, ecs edgeapi.EdgeClusterStatusRequest) error {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeEdgeClusterStatus, rsName)
-	edgeClusterStatusMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgeClusterModuleName, resource, model.UpdateOperation, ecs)
+	edgeClusterStatusMsg := message.BuildMsg(modules.MetaGroup, "", modules.ClusterdModuleName, resource, model.UpdateOperation, ecs)
 	_, err := c.send.SendSync(edgeClusterStatusMsg)
 	if err != nil {
 		return fmt.Errorf("update edgeClusterStatus failed, err: %v", err)

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -49,7 +49,7 @@ func feedbackError(err error, info string, request model.Message) {
 	switch source {
 	case modules.EdgedModuleName:
 		sendToEdged(errResponse, request.IsSync())
-	case modules.EdgeClusterModuleName:
+	case modules.ClusterdModuleName:
 		sendToEdgeCluster(errResponse, request.IsSync())
 	default:
 		sendToCloud(errResponse)
@@ -69,7 +69,7 @@ func sendToEdged(message *model.Message, sync bool) {
 }
 
 func sendToEdgeCluster(message *model.Message, sync bool) {
-	sendToEdgeModules(message, sync, modules.EdgeClusterModuleName)
+	sendToEdgeModules(message, sync, modules.ClusterdModuleName)
 }
 
 func sendToEdgeMesh(message *model.Message, sync bool) {
@@ -354,7 +354,7 @@ func (m *metaManager) processUpdate(message model.Message) {
 		sendToCloud(&message)
 		resp := message.NewRespByMessage(&message, OK)
 		sendToEdged(resp, message.IsSync())
-	case modules.EdgeClusterModuleName:
+	case modules.ClusterdModuleName:
 		sendToCloud(&message)
 		resp := message.NewRespByMessage(&message, OK)
 		sendToEdgeCluster(resp, message.IsSync())

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -50,7 +50,7 @@ func feedbackError(err error, info string, request model.Message) {
 	case modules.EdgedModuleName:
 		sendToEdged(errResponse, request.IsSync())
 	case modules.ClusterdModuleName:
-		sendToEdgeCluster(errResponse, request.IsSync())
+		sendToClusterd(errResponse, request.IsSync())
 	default:
 		sendToCloud(errResponse)
 	}
@@ -68,7 +68,7 @@ func sendToEdged(message *model.Message, sync bool) {
 	sendToEdgeModules(message, sync, modules.EdgedModuleName)
 }
 
-func sendToEdgeCluster(message *model.Message, sync bool) {
+func sendToClusterd(message *model.Message, sync bool) {
 	sendToEdgeModules(message, sync, modules.ClusterdModuleName)
 }
 
@@ -124,8 +124,8 @@ func isEdgeMeshResource(resType string) bool {
 		resType == model.ResourceTypePodlist
 }
 
-// if resource type is EdgeCluster related
-func isEdgeClusterResource(resType string) bool {
+// if resource type is clusterd related
+func isClusterdResource(resType string) bool {
 	return resType == constants.ResourceTypeMission
 }
 
@@ -219,8 +219,8 @@ func (m *metaManager) processInsert(message model.Message) {
 	if isEdgeMeshResource(resType) {
 		// Notify edgemesh
 		sendToEdgeMesh(&message, false)
-	} else if isEdgeClusterResource(resType) {
-		sendToEdgeCluster(&message, false)
+	} else if isClusterdResource(resType) {
+		sendToClusterd(&message, false)
 	} else {
 		// Notify edged
 		sendToEdged(&message, false)
@@ -357,12 +357,12 @@ func (m *metaManager) processUpdate(message model.Message) {
 	case modules.ClusterdModuleName:
 		sendToCloud(&message)
 		resp := message.NewRespByMessage(&message, OK)
-		sendToEdgeCluster(resp, message.IsSync())
+		sendToClusterd(resp, message.IsSync())
 	case cloudmodules.EdgeControllerModuleName, cloudmodules.DynamicControllerModuleName:
 		if isEdgeMeshResource(resType) {
 			sendToEdgeMesh(&message, message.IsSync())
-		} else if isEdgeClusterResource(resType) {
-			sendToEdgeCluster(&message, message.IsSync())
+		} else if isClusterdResource(resType) {
+			sendToClusterd(&message, message.IsSync())
 		} else {
 			sendToEdged(&message, message.IsSync())
 		}
@@ -408,8 +408,8 @@ func (m *metaManager) processResponse(message model.Message) {
 	if message.GetSource() == CloudControlerModel {
 		if resType == constants.ResourceTypeService || resType == constants.ResourceTypeEndpoints {
 			sendToEdgeMesh(&message, message.IsSync())
-		} else if isEdgeClusterResource(resType) {
-			sendToEdgeCluster(&message, message.IsSync())
+		} else if isClusterdResource(resType) {
+			sendToClusterd(&message, message.IsSync())
 		} else {
 			sendToEdged(&message, message.IsSync())
 		}
@@ -449,8 +449,8 @@ func (m *metaManager) processDelete(message model.Message) {
 		return
 	}
 
-	if isEdgeClusterResource(resType) {
-		sendToEdgeCluster(&message, message.IsSync())
+	if isClusterdResource(resType) {
+		sendToClusterd(&message, message.IsSync())
 	} else {
 		// Notify edged
 		sendToEdged(&message, false)
@@ -472,7 +472,7 @@ func (m *metaManager) processQuery(message model.Message) {
 			resp := message.NewRespByMessage(&message, *metas)
 			resp.SetRoute(MetaManagerModuleName, resp.GetGroup())
 			if m.edgeClusterMode {
-				sendToEdgeCluster(resp, message.IsSync())
+				sendToClusterd(resp, message.IsSync())
 			} else {
 				sendToEdged(resp, message.IsSync())
 			}
@@ -495,7 +495,7 @@ func (m *metaManager) processQuery(message model.Message) {
 		if resType == constants.ResourceTypeService || resType == constants.ResourceTypeEndpoints || resType == constants.ResourceTypeListener {
 			sendToEdgeMesh(resp, message.IsSync())
 		} else if m.edgeClusterMode {
-			sendToEdgeCluster(resp, message.IsSync())
+			sendToClusterd(resp, message.IsSync())
 		} else {
 			sendToEdged(resp, message.IsSync())
 		}
@@ -543,8 +543,8 @@ func (m *metaManager) processRemoteQuery(message model.Message) {
 		resp.BuildHeader(resp.GetID(), originalID, resp.GetTimestamp())
 		if resType == constants.ResourceTypeService || resType == constants.ResourceTypeEndpoints {
 			sendToEdgeMesh(&resp, message.IsSync())
-		} else if isEdgeClusterResource(resType) {
-			sendToEdgeCluster(&message, message.IsSync())
+		} else if isClusterdResource(resType) {
+			sendToClusterd(&message, message.IsSync())
 		} else {
 			sendToEdged(&resp, message.IsSync())
 		}

--- a/keadm/cmd/keadm/app/cmd/common/config.go
+++ b/keadm/cmd/keadm/app/cmd/common/config.go
@@ -100,7 +100,7 @@ func WriteEdgeModulesYamlFile(path string) error {
 				"edged",
 				"twin",
 				"edgemesh",
-				"edgecluster",
+				"clusterd",
 			},
 		},
 	}

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -167,7 +167,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				TunnelServer:            net.JoinHostPort("127.0.0.1", strconv.Itoa(constants.DefaultTunnelPort)),
 				WriteDeadline:           15,
 			},
-			EdgeCluster: &EdgeCluster{
+			Clusterd: &Clusterd{
 				Enable:               true,
 				Name:                 "",
 				Kubeconfig:           "",

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -106,8 +106,8 @@ type Modules struct {
 	// +Required
 	EdgeStream *EdgeStream `json:"edgeStream,omitempty"`
 
-	// EdgeCluster indicates EdgeCluster module config
-	EdgeCluster *EdgeCluster `json:"edgeCluster,omitempty"`
+	// Clusterd indicates Clusterd module config
+	Clusterd *Clusterd `json:"clusterd,omitempty"`
 }
 
 // Edged indicates the config fo edged module
@@ -475,8 +475,8 @@ type EdgeStream struct {
 	WriteDeadline int32 `json:"writeDeadline,omitempty"`
 }
 
-// EdgeCluster indicates the edge cluster config
-type EdgeCluster struct {
+// Clusterd indicates the clusterd config
+type Clusterd struct {
 	// Enable indicates whether edge cluster is enabled, if set to false, skip checking other configs.
 	// default true
 	Enable bool `json:"enable,omitempty"`

--- a/tests/edgecluster/data/sample_edgecore_with_edgecluster.yaml
+++ b/tests/edgecluster/data/sample_edgecore_with_edgecluster.yaml
@@ -20,7 +20,7 @@ modules:
       readDeadline: 15
       server: 172.31.22.126:10000
       writeDeadline: 15
-  edgeCluster:
+  clusterd:
     enable: true
     kubeconfig: /root/arktos.kubeconfig
     kubeDistro: arktos


### PR DESCRIPTION
This is a refactoring PR to rename "edgecluster" module to "clusterd".

The original name of "edgeclsuter" is confusing, as we also defined a CRD type of "edgecluster". With this change:
1. EdgeCluster is a resource type, comparable to node.
2. clusterd is a module name, comparable to edged. 

Verification:
The features implemented in this PoC work, such as mission deployment, edgecluster report, continue to work after this refactoring. 