### PR TITLE
mission state pruner in cloud & force mission state report after long idleness in clusterd

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller"
 	kele "github.com/kubeedge/kubeedge/cloud/pkg/leaderelection"
+	"github.com/kubeedge/kubeedge/cloud/pkg/missionstatepruner"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router"
 	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
@@ -113,4 +114,5 @@ func registerModules(c *v1alpha1.CloudCoreConfig) {
 	cloudstream.Register(c.Modules.CloudStream)
 	router.Register(c.Modules.Router)
 	dynamiccontroller.Register(c.Modules.DynamicController)
+	missionstatepruner.Register(c.Modules.MissionStatePruner)
 }

--- a/cloud/pkg/common/modules/modules.go
+++ b/cloud/pkg/common/modules/modules.go
@@ -22,5 +22,8 @@ const (
 	RouterModuleName = "router"
 	RouterGroupName  = "router"
 
+	MissionStatePrunerModuleName = "missionstatepruner"
+	MissionStatePrunerGroupName  = "missionstatepruner"
+
 	UserGroup = "user"
 )

--- a/cloud/pkg/missionstatepruner/config/config.go
+++ b/cloud/pkg/missionstatepruner/config/config.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"sync"
+
+	configv1alpha1 "github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+var Config Configure
+var once sync.Once
+
+type Configure struct {
+	MissionStatePruner *configv1alpha1.MissionStatePruner
+}
+
+func InitConfigure(msp *configv1alpha1.MissionStatePruner) {
+	once.Do(func() {
+		Config = Configure{
+			MissionStatePruner: msp,
+		}
+	})
+}

--- a/cloud/pkg/missionstatepruner/pruner.go
+++ b/cloud/pkg/missionstatepruner/pruner.go
@@ -1,0 +1,122 @@
+package missionstatepruner
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/beehive/pkg/core"
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	crdClientset "github.com/kubeedge/kubeedge/cloud/pkg/client/clientset/versioned"
+	keclient "github.com/kubeedge/kubeedge/cloud/pkg/common/client"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/cloud/pkg/missionstatepruner/config"
+	configv1alpha1 "github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+const (
+	EdgeCluster_offline = "cluster offline"
+)
+
+//Mission state prune periodically update the mission state when some edgeclusters become offline
+type MissionStatePruner struct {
+	enable             bool
+	syncInterval       time.Duration
+	edgeclusterTimeout time.Duration
+	// Here we use a client, instead of an informer/lister, to check whether edgeclusters are offline. Reaso
+	// Reason I: We check the edge cluster once for a long period ( default one per minute), to avoid noise of edge cluster state flip&flop.
+	// So a long connection used by informer/lister actually is more expensive.
+	// Reason II: informers are good at detecting object changes. But here we are interested in edgeclusters whose status have NOT changed for a long time.
+	crdClient crdClientset.Interface
+}
+
+func newMissionStatePruner(msp *configv1alpha1.MissionStatePruner) *MissionStatePruner {
+	return &MissionStatePruner{
+		enable:             msp.Enable,
+		crdClient:          keclient.GetCRDClient(),
+		syncInterval:       time.Duration(msp.SyncInterval) * time.Second,
+		edgeclusterTimeout: time.Duration(msp.EdgeClusterTimeout) * time.Second,
+	}
+}
+
+func Register(msp *configv1alpha1.MissionStatePruner) {
+	config.InitConfigure(msp)
+	core.Register(newMissionStatePruner(msp))
+}
+
+// Name of controller
+func (msp *MissionStatePruner) Name() string {
+	return modules.MissionStatePrunerModuleName
+}
+
+// Group of controller
+func (msp *MissionStatePruner) Group() string {
+	return modules.SyncControllerModuleGroup
+}
+
+// Group of controller
+func (msp *MissionStatePruner) Enable() bool {
+	return msp.enable
+}
+
+// Start controller
+func (msp *MissionStatePruner) Start() {
+	go wait.Until(msp.checkAndPrune, msp.syncInterval, beehiveContext.Done())
+}
+
+func (msp *MissionStatePruner) checkAndPrune() {
+	allEdgeClusters, err := msp.crdClient.EdgeclustersV1().EdgeClusters().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("Error in listing edge clusters: %v", err)
+		return
+	}
+
+	deadEdgeClusters := map[string]bool{}
+	for _, ec := range allEdgeClusters.Items {
+		if time.Now().Sub(ec.Status.LastHeartBeat.Time) > msp.edgeclusterTimeout {
+			deadEdgeClusters[ec.Name] = true
+		}
+	}
+
+	allMissions, err := msp.crdClient.EdgeclustersV1().Missions().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("Error in listing missions: %v", err)
+		return
+	}
+
+	for _, mission := range allMissions.Items {
+		changed := false
+
+		for key, val := range mission.State {
+			parts := strings.Split(key, "/")
+			switch len(parts) {
+			case 0:
+				// it should not happen
+				klog.Errorf("invalid mission state key.")
+				continue
+			case 1:
+				if deadEdgeClusters[key] && val != EdgeCluster_offline {
+					mission.State[key] = EdgeCluster_offline
+					changed = true
+				}
+			default:
+				if deadEdgeClusters[parts[0]] {
+					delete(mission.State, key)
+					changed = true
+				}
+			}
+		}
+		if changed {
+			klog.V(3).Infof("Pruning the state of mission %v ...", mission.Name)
+			_, err := msp.crdClient.EdgeclustersV1().Missions().Update(context.Background(), &mission, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Warningf("Error in updating the state of mission %v: %v", mission.Name, err)
+			}
+		}
+	}
+
+}

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -157,8 +157,12 @@ const (
 
 	// edgeCluster
 	DefaultEdgeClusterStatusUpdateInterval = 10
-	DefaultInformerResyncInterval          = 1
+	DefaultStateResyncInterval             = 1
 	DefaultMissionStateWatchWorkers        = 4
 	DefaultRegisterNamespace               = "default"
 	DefaultMissionStateUpdateInterval      = 10
+
+	//missionstatepruner
+	DefaultStateSyncInterval  = 60
+	DefaultEdgeClusterTimeout = 60
 )

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -168,6 +168,11 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				Port:        9443,
 				RestTimeout: 60,
 			},
+			MissionStatePruner: &MissionStatePruner{
+				Enable:             false,
+				SyncInterval:       constants.DefaultStateSyncInterval,
+				EdgeClusterTimeout: constants.DefaultEdgeClusterTimeout,
+			},
 		},
 		LeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       false,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -76,6 +76,8 @@ type Modules struct {
 	CloudStream *CloudStream `json:"cloudStream,omitempty"`
 	// Router indicates router module config
 	Router *Router `json:"router,omitempty"`
+
+	MissionStatePruner *MissionStatePruner `json:"missionstatepruner,omitempty"`
 }
 
 // CloudHub indicates the config of CloudHub module.
@@ -413,4 +415,15 @@ type Router struct {
 	Address     string `json:"address,omitempty"`
 	Port        uint32 `json:"port,omitempty"`
 	RestTimeout uint32 `json:"restTimeout,omitempty"`
+}
+
+type MissionStatePruner struct {
+	// default true
+	Enable bool `json:"enable,omitempty"`
+	// the interval (in seconds) that the pruner will prune the offline mission state
+	//default 60
+	SyncInterval int `json:"syncInterval,omitempty"`
+	//The seconds that an edgecluster will be deemed as 'offline' if it has not reported a heartbeat
+	//default 60
+	EdgeClusterTimeout int `json:"edgeClusterTimeout,omitempty"`
 }

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -175,7 +175,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				Labels:                          map[string]string{},
 				EdgeClusterStatusUpdateInterval: constants.DefaultEdgeClusterStatusUpdateInterval,
 				MissionStateUpdateInterval:      constants.DefaultMissionStateUpdateInterval,
-				InformerResyncInterval:          constants.DefaultInformerResyncInterval,
+				ResyncInterval:                  constants.DefaultStateResyncInterval,
 				RegisterCluster:                 true,
 				RegisterNamespace:               constants.DefaultRegisterNamespace,
 				MissionStateWatchWorkers:        constants.DefaultMissionStateWatchWorkers,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -511,7 +511,7 @@ type Clusterd struct {
 	// default get local host ip
 	NodeIP string `json:"nodeIP"`
 
-	InformerResyncInterval int32 `json:"informerResyncInterval,omitempty"`
+	ResyncInterval int32 `json:"resyncInterval,omitempty"`
 
 	MissionStateWatchWorkers int `json:"missionStateWatchWorkers,omitempty"`
 }


### PR DESCRIPTION
This PR address the issue of mission status reporting when the edge cluster goes offline with a light-weight solution.

With this PR:
1. When an edge cluster goes offline, the mission state about the offline clusters in the mission objects will be set to "cluster offline". And the state of the underlying edgeclusters of the offline clusters will be removed. we call this process **Mission State Pruning**.
2. When the edge cluster comes back to life, the mission state of these edge clusters will be updated.

To achieve this, the code changes are presented in this PR:
1. A new module, MissionStatePruner, is added to cloudcore. It periodically checks the last heart beat time of edgeclusters. If an edgecluster has no heartbeat for a long period ( it is 1 minute by default), this edge cluster is deemed as offline and this module does the mission state pruning about this edge cluster.
2. Changed the behavior of mission status reporting in clusterd module. Previously, the mission state is reported only if there is any change. The new behavior is to report the state if it the state has not been reported for a long period (we set it to one minute), even if there is no change. 

#### Verification
1. start an kubeedge cluster with two cascading edgeclusters (layer-I and layer-II in the direction from cloud to edge). A mission is deployed to the edge clusters. The mission state is as follows:

![image](https://user-images.githubusercontent.com/51831990/119192365-e51ed180-ba34-11eb-86be-b23920dc9ddd.png)

2. Turn off the edgecore process in the layer-I and wait for 1 minute. The mission state is as follows:

![image](https://user-images.githubusercontent.com/51831990/119192549-3202a800-ba35-11eb-8f5c-5e85976c155f.png)

3. restart the edgecore process in the layer-I and wait for 1 minute. The mission state is as follows:

![image](https://user-images.githubusercontent.com/51831990/119192674-5d859280-ba35-11eb-9ff5-bdca02d96c40.png)
