### PR TITLE
resync missions in edgeclusters periodically

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -158,6 +158,7 @@ func isListResource(msg *beehiveModel.Message) bool {
 	if strings.Contains(msgResource, beehiveModel.ResourceTypePodlist) ||
 		strings.Contains(msgResource, commonconst.ResourceTypeServiceList) ||
 		strings.Contains(msgResource, commonconst.ResourceTypeEndpointsList) ||
+		strings.Contains(msgResource, beehiveModel.ResourceTypeMissionList) ||
 		strings.Contains(msgResource, "membership") ||
 		strings.Contains(msgResource, "twin/cloud_updated") {
 		return true

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -149,7 +149,8 @@ const (
 	CSIOperationTypeControllerUnpublishVolume = "controllerunpublishvolume"
 	CSISyncMsgRespTimeout                     = 1 * time.Minute
 
-	ResourceTypeMission = "mission"
+	ResourceTypeMission     = "mission"
+	ResourceTypeMissionList = "missionlist"
 
 	// ServerPort is the default port for the edgecore server on each host machine.
 	// May be overridden by a flag at startup in the future.

--- a/edge/pkg/clusterd/clusterd.go
+++ b/edge/pkg/clusterd/clusterd.go
@@ -153,7 +153,7 @@ func (e *clusterd) syncCloud() {
 		klog.V(4).Infof("result content is %s", result.Content)
 		_, resType, resID, err := util.ParseResourceEdge(result.GetResource(), result.GetOperation())
 		if err != nil {
-			klog.Errorf("Failed in edge resource parsing: %v", err)
+			klog.Errorf("failed in edge resource parsing: %v", err)
 			continue
 		}
 		switch resType {

--- a/edge/pkg/clusterd/clusterd.go
+++ b/edge/pkg/clusterd/clusterd.go
@@ -152,6 +152,10 @@ func (e *clusterd) syncCloud() {
 		}
 		klog.V(4).Infof("result content is %s", result.Content)
 		_, resType, resID, err := util.ParseResourceEdge(result.GetResource(), result.GetOperation())
+		if err != nil {
+			klog.Errorf("Failed in edge resource parsing: %v", err)
+			continue
+		}
 		switch resType {
 		case constants.ResourceTypeMission:
 			if op == model.ResponseOperation && resID == "" {
@@ -171,7 +175,7 @@ func (e *clusterd) syncCloud() {
 					continue
 				}
 			}
-
+			
 		default:
 			klog.Errorf("resource type %s is not supported", resType)
 			continue

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -267,7 +267,6 @@ func processMissionList(content []byte) error {
 		}
 
 		if _, exists := strayKeys[daoKey]; exists {
-			//dao.DeleteMetaByKey
 			delete(strayKeys, daoKey)
 		}
 	}

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	edgeclustersv1 "github.com/kubeedge/kubeedge/cloud/pkg/apis/edgeclusters/v1"
 	cloudmodules "github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/common/constants"
 	connect "github.com/kubeedge/kubeedge/edge/pkg/common/cloudconnection"
@@ -126,7 +127,8 @@ func isEdgeMeshResource(resType string) bool {
 
 // if resource type is clusterd related
 func isClusterdResource(resType string) bool {
-	return resType == constants.ResourceTypeMission
+	return resType == constants.ResourceTypeMission ||
+		resType == constants.ResourceTypeMissionList
 }
 
 func isConnected() bool {
@@ -230,6 +232,56 @@ func (m *metaManager) processInsert(message model.Message) {
 	sendToCloud(resp)
 }
 
+func processMissionList(content []byte) error {
+	missionRecords, err := dao.QueryAllMetaByType(constants.ResourceTypeMission)
+	if err != nil {
+		return fmt.Errorf("Error in getting mission records in db: %v", err)
+	}
+
+	strayKeys := map[string]bool{}
+	for _, record := range *missionRecords {
+		strayKeys[record.Key] = true
+	}
+	var missionList []edgeclustersv1.Mission
+	err = json.Unmarshal(content, &missionList)
+	if err != nil {
+		return fmt.Errorf("Unmarshal update message content failed, %s", content)
+	}
+
+	for _, mission := range missionList {
+		data, err := json.Marshal(mission)
+		if err != nil {
+			klog.Errorf("Marshal mission content failed, %v", mission)
+			continue
+		}
+
+		daoKey := fmt.Sprintf("%s/%s/%s", "default", constants.ResourceTypeMission, mission.Name)
+		meta := &dao.Meta{
+			Key:   daoKey,
+			Type:  constants.ResourceTypeMission,
+			Value: string(data)}
+		err = dao.InsertOrUpdate(meta)
+		if err != nil {
+			klog.Errorf("Update meta failed, %v", meta)
+			continue
+		}
+
+		if _, exists := strayKeys[daoKey]; exists {
+			//dao.DeleteMetaByKey
+			delete(strayKeys, daoKey)
+		}
+	}
+
+	for k := range strayKeys {
+		err = dao.DeleteMetaByKey(k)
+		if err != nil {
+			klog.Errorf("Error in delete meta %v", k)
+		}
+	}
+
+	return nil
+}
+
 func (m *metaManager) processUpdate(message model.Message) {
 
 	var err error
@@ -248,8 +300,15 @@ func (m *metaManager) processUpdate(message model.Message) {
 	imitator.DefaultV2Client.Inject(message)
 
 	resKey, resType, _ := parseResource(message.GetResource())
-	if resType == constants.ResourceTypeServiceList || resType == constants.ResourceTypeEndpointsList || resType == model.ResourceTypePodlist {
+	if resType == constants.ResourceTypeServiceList || resType == constants.ResourceTypeEndpointsList || resType == model.ResourceTypePodlist || resType == constants.ResourceTypeMissionList {
 		switch resType {
+		case constants.ResourceTypeMissionList:
+			err = processMissionList(content)
+			if err != nil {
+				klog.Errorf("Error to process mission list; %v", err)
+			}
+			return
+
 		case constants.ResourceTypeEndpointsList:
 			var epsList []v1.Endpoints
 			err = json.Unmarshal(content, &epsList)

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -25,6 +25,7 @@ const (
 	ResourceTypeRule              = "rule"
 	ResourceTypeRuleEndpoint      = "ruleendpoint"
 	ResourceTypeMission           = "mission"
+	ResourceTypeMissionList       = "missionlist"
 	ResourceTypeMissionState      = "missionstate"
 	ResourceTypeEdgeCluster       = "edgecluster"
 	ResourceTypeEdgeClusterStatus = "edgeclusterstatus"


### PR DESCRIPTION
With this PR, the edgecontroller will align the missions in edgeclusters with the missions in the cloud side.

In more details: Every time an edgecluster object is added or updated, edgecontroller will look into the missions deployed in the edge cluster. If there is any discrepancy between the missions of the edge side and the cloud side, the edge controller will send an MissionList message to the ege side. The MetaManager will update the mission records saved in its DB after receiving the MissionList message. Finally, the clusterd will pick up the changes and update the missions in its managed edge cluster.

### Verification
The PR is verified with the following test scenario :
1. Start the cloudcore
2. keep the edgecore off and deploy a new mission A
3. start edgecore
It is verified that the mission A is deployed to the edge cluster

4. stop the edgecore process
5. delete the mission A and deploy a new mission B in the cloud cluster.
6. restart the edgecore process, wait like 20 seconds
7. It is verified that in the edge cluster, mission A is removed and mission B is active.

8. Manually delete the mission B in the edge cluster.
9. wait 20 seconds.
10. It is verified that mission B is re-deployed and still active in the edge cluster.

### Possible improvement
In this PR, the mission list message will be sent out only when it is necessary, namely when the edge controller finds the missions in the edge is different from the missions in the cloud side. For the PoC purpose, I compare the missions of edge and cloud by their names. Therefore, if a mission's spec is manually changed in the edge side with the mission name untouched, the cloud side cannot detect it.

 I am thinking this issue might be solved by clusterd sending a Mission Spec hash value in the edge-cluster status message, where the edgecontroller get the information of missons running on the edge cluster. Then the edge controller can also check whether the mission Spec is different from that in the cloud side. It is left for further discussion .
