### PR TITLE
test plan doc draft

### DIFF
--- a/build/crds/edgecluster/edgecluster_v1.yaml
+++ b/build/crds/edgecluster/edgecluster_v1.yaml
@@ -23,15 +23,7 @@ spec:
       JSONPath: .state.lastheartbeat
     - name: HealthStatus
       type: string
-      description: Whether the cluster is healthy and accessible
       JSONPath: .state.healthstatus
-    - name: Nodes
-      type: string
-      description: nodes
-      JSONPath: .state.nodes
-    - name: EdgeNodes
-      type: string
-      JSONPath: .state.edgenodes
     - name: SubEdgeClusters
       type: string
       JSONPath: .state.subedgeclusterstates

--- a/docs/fornax_test/830_release_testplan.md
+++ b/docs/fornax_test/830_release_testplan.md
@@ -1,6 +1,6 @@
 # Fornax End-to-End Test for 2021-8-30 Release
 
-This test suite verifies the features for 2021-8-30 release. Detaile explanation about these features are given in [design doc](https://github.com/CentaurusInfra/fornax/tree/main/docs/fornax-design/530_design.md). 
+This test suite verifies the features for 2021-8-30 release. Detailed explanation about these features are given in [design doc](https://github.com/CentaurusInfra/fornax/tree/main/docs/fornax-design/530_design.md). 
 
 The following tests assume four clusters, denoted as A,B,C and D, are created and configured for tests. A,B,C are kubernetes clusters created using kubeadm, while cluster D is an arktos cluster started by running script arktos-up.sh (https://github.com/CentaurusInfra/arktos/blob/master/hack/arktos-up.sh). These clusters are configured in a hierarchical topology, where Cluster B is an edge cluster to Cluster A, C edge to B, and D edge to C. Detailed instructions on how to configure the hierarchical connection among these clusters are given in the doc test_cluster_setup.md in the same directory as this doc. 
 
@@ -15,7 +15,7 @@ Test Case 1: Register Hierarchical Edge Clusters with Cloud
 
 Test Case 3: An edge cluster re-connects to the cloud
 
-Test Case 5: An edge cluster continue to work when disconnected from the cloud
+Test Case 5: An edge cluster continues to work when disconnected from the cloud
 
 Test Case 6: An edge cluster conintues to monintor its sub-edge-clusters when disconnected from cloud
 
@@ -35,15 +35,15 @@ Test Case 10: The mission status of a cluster is "cluster unreachable" if cluste
 
 Test Case 11: Delete workload to edge clusters using mission
 
-Test Case 12: Deploy workload to an edge cluster with specific name
+Test Case 12: Deploy workload to an edge cluster with a specific name
 
 Test Case 13: Deploy workload to selective edge clusters with given labels
 
 Test Case 15: An edge cluster picks up the new mission added during its disconnection when reconnected to the cloud
 
-Test Case 16: An edge cluster updates the mission updated during its disconnection when reconnected to the cloud
+Test Case 16: An edge cluster picks up the change when reconnected if the mission is updated during its disconnection
 
-Test Case 17: An edge cluster deletes the mission deleted during its disconnection when reconnected to the cloud
+Test Case 17: An edge cluster deletes a mission when reconnected if the mission is deleted during its disconnection 
 
 Test Case 18: The mission content deleted in edge cluster will be re-instated
 
@@ -61,10 +61,10 @@ Test Case 20: The status of edge cluster is "Unhealthy" if the clusterd is conne
 
 ## Test Cases
 
-**Note: By default, the commands in this doc are run from the root directory of the fornax repo. If not specified, the command is run on the operating machine of Cluster A, which will be referred as "root operator machine" in the rest of this document.**
+**Note: By default, the commands in this doc are run from the root directory of the fornax repo. If not specified, the command is run on the machine of Cluster A, which will be referred as "root operator machine" in the rest of this document.**
 
 
-**Test Case 1: Register Cascading Edge Clusters with Cloud**
+**Test Case 1: Register Hierarchical Edge Clusters with Cloud**
 
 Step 1: start kubeedge cloudcore in the root operator machine, using command:
 ```
@@ -169,7 +169,7 @@ kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
 Verify that the deployment specified in the mission content is created in the edge clusters of B, C, D. 
 
 
-**Test Case 5: An edge cluster continue to work when disconnected from the cloud**
+**Test Case 5: An edge cluster continues to work when disconnected from the cloud**
 
 Continuing from the previous test case, do the following:
 
@@ -286,7 +286,7 @@ kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
 ```
 Verify that the deployment specified in the mission content is gone in each edge cluster. 
 
-**Test Case 12: Deploy workload to an edge cluster with specific name**
+**Test Case 12: Deploy workload to an edge cluster with a specific name**
 
 Step 1. update tests/edgecluster/data/missions/deployment-to-given-clusters.yaml to change the value of spec/placement/cluster/Name to be the name of cluster C.
 
@@ -427,7 +427,7 @@ kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
 ```
 Verify that the deployment specified in the mission content is created in the edge clusters B, C and D.  
 
-**Test Case 16: An edge cluster updates the mission updated during its disconnection when reconnected to the cloud**
+**Test Case 16: An edge cluster picks up the change when reconnected if the mission is updated during its disconnection**
 
 Continuing from the previous test case, do the following:
 
@@ -468,7 +468,7 @@ kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
 Verify that the number of replicas in the deployment is updated in the edge clusters B, C and D. 
 
 
-**Test Case 17: An edge cluster deletes the mission deleted during its disconnection when reconnected to the cloud**
+**Test Case 17: An edge cluster deletes a mission when reconnected if the mission is deleted during its disconnection **
 
 Continuing from the previous test case, do the following:
 

--- a/docs/fornax_test/830_release_testplan.md
+++ b/docs/fornax_test/830_release_testplan.md
@@ -1,0 +1,584 @@
+# Fornax End-to-End Test for 2021-8-30 Release
+
+This test suite verifies the features for 2021-8-30 release. Detaile explanation about these features are given in [design doc](https://github.com/CentaurusInfra/fornax/tree/main/docs/fornax-design/530_design.md). 
+
+The following tests assume four clusters, denoted as A,B,C and D, are created and configured for tests. A,B,C are kubernetes clusters created using kubeadm, while cluster D is an arktos cluster started by running script arktos-up.sh (https://github.com/CentaurusInfra/arktos/blob/master/hack/arktos-up.sh). These clusters are configured in a hierarchical topology, where Cluster B is an edge cluster to Cluster A, C edge to B, and D edge to C. Detailed instructions on how to configure the hierarchical connection among these clusters are given in the doc test_cluster_setup.md in the same directory as this doc. 
+
+
+## Overview of Test Coverage
+
+The test cases can be classified into three groups. 
+
+**Group I: EdgeCluster Connection**
+
+Test Case 1: Register Hierarchical Edge Clusters with Cloud
+
+Test Case 3: An edge cluster re-connects to the cloud
+
+Test Case 5: An edge cluster continue to work when disconnected from the cloud
+
+Test Case 6: An edge cluster conintues to monintor its sub-edge-clusters when disconnected from cloud
+
+
+
+**Group II: Workload Managment**
+
+Test Case 4: Deploy workload (deployment) to edge clusters using mission
+
+Test Case 7: Deploy workload (job) to edge clusters using mission
+
+Test Case 8: Check mission status using command "kubectl get missions" 
+
+Test Case 9: Update workload to edge clusters using mission
+
+Test Case 10: The mission status of a cluster is "cluster unreachable" if cluster disconnected
+
+Test Case 11: Delete workload to edge clusters using mission
+
+Test Case 12: Deploy workload to an edge cluster with specific name
+
+Test Case 13: Deploy workload to selective edge clusters with given labels
+
+Test Case 15: An edge cluster picks up the new mission added during its disconnection when reconnected to the cloud
+
+Test Case 16: An edge cluster updates the mission updated during its disconnection when reconnected to the cloud
+
+Test Case 17: An edge cluster deletes the mission deleted during its disconnection when reconnected to the cloud
+
+Test Case 18: The mission content deleted in edge cluster will be re-instated
+
+Test Case 19: The mission content changed in edge cluster will be reverted automatically
+
+
+**Group III: Montioring EdgeCluster & Mission States**
+
+Test Case 2: Check edge cluster status when disconnected from the cloud 
+
+Test Case 14: Check edge cluster status when connected from the cloud 
+
+Test Case 20: The status of edge cluster is "Unhealthy" if the clusterd is connected but the underlying cluster is unreachable
+
+
+## Test Cases
+
+**Note: By default, the commands in this doc are run from the root directory of the fornax repo. If not specified, the command is run on the operating machine of Cluster A, which will be referred as "root operator machine" in the rest of this document.**
+
+
+**Test Case 1: Register Cascading Edge Clusters with Cloud**
+
+Step 1: start kubeedge cloudcore in the root operator machine, using command:
+```
+_output/local/bin/cloudcore
+```
+
+Step 2: Run the following command in the root operator machine to verify that **NO** edge cluster is registered.
+```
+kubectl get edgeclusters
+```
+
+Step 3: in Cluster B machine, start the edgecore in edge-cluster mode, with command 
+```
+_output/local/bin/edgecore --edgecluster
+```
+
+
+Step 4: wait 10-20 seconds, in the root operator machine, verify that the edge-cluster B shows up in the command ouput of 
+```
+kubectl get edgeclusters
+```
+
+Step 5: in cluster B machine, start cloudcore
+```
+_output/local/bin/cloudcore
+```
+
+Step 6: in Cluster C machine, start the edgecore in edge-cluster mode, with command 
+```
+_output/local/bin/edgecore --edgecluster
+```
+
+
+Step 7: wait 30-40 seconds, in Cluster A machine, verify that the C is shown as a sub-edge-cluster of edge-cluster B in the command ouput of 
+```
+kubectl get edgeclusters
+```
+
+Step 8: in cluster C machine, start cloudcore
+```
+_output/local/bin/cloudcore
+```
+
+Step 9:in Cluster D machine, start the edgecore in edge-cluster mode, with command 
+```
+_output/local/bin/edgecore --edgecluster
+```
+
+
+Step 10: wait 50-60 seconds, in Cluster A machine, run command, 
+```
+kubectl get edgeclusters
+```
+Verify that the clusters C and C/D (C/D mean D is a sub-cluster of C) are shown as sub-edge-clusters of edge-cluster B in the command ouput of 
+
+**Test Case 2: Check edge cluster status when disconnected from the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: kill the process of edgecore in cluster B machine.
+
+Step 2: wait for 2 minutes. Run the command in the root operator machine,
+```
+kubectl get edgeclusters
+```
+Verify the edge cluster B exists but its state is "Disconnected".
+
+Also verify that the info of "SubEdgeClusters" C and C/D is cleared. 
+
+**Test Case 3: An edge cluster re-connects to the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: in cluster B machine, restart the edgecore in edge-cluster mode, using command 
+```
+edgecore --edgecluster
+```
+
+Step 4: wait 10-20 seconds, verify that the state of the edge-cluster B is "healthy" in the command ouput 
+```
+kubectl get edgeclusters
+```
+
+Also verify that the states of cluster C and C/D are displayed in the section of "SubEdgeClusters" in the command output. 
+
+**Test Case 4: Deploy workload (deployment) to edge clusters using mission**
+
+Step 1: Run the command in the root operator machine
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 2: run the following command to verify the mission is deployed and the status of the mission is shown and updated regularly.
+```
+kubectl get missions
+```
+
+Step 3: run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment specified in the mission content is created in the edge clusters of B, C, D. 
+
+
+**Test Case 5: An edge cluster continue to work when disconnected from the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: kill the process of edgecore in cluster B. 
+
+Step 2: run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment created via missions in the previous test case is still active in each edge cluster. 
+
+
+**Test Case 6: An edge cluster conintues to monintor its sub-edge-clusters when disconnected from cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: Run command 
+```
+kubectl get edgecluster --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Verify the info of edge cluster C is displayed correctly, just like cluster B is not disconnected from the cloud.
+
+Step 2: Run command 
+```
+kubectl get mission --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Verify the info of mission deployment-to-all is displayed correctly, just like cluster B is not disconnected from the cloud.
+
+**Test Case 7: Deploy workload (job) to edge clusters using mission**
+
+Step 1: Run the command in the root operator machine
+```
+kubectl apply -f tests/edgecluster/data/missions/job-to-all.yaml
+```
+
+Step 2: run the following command to verify the mission is deployed
+```
+kubectl get missions
+```
+
+Step 3: run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get jobs --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the job specified in the mission content is created in each edge cluster. 
+
+
+**Test Case 8: Check mission status using command "kubectl get missions"** 
+
+Continuing from the previous test case,
+
+Step 1: run command and watch the output for 1 minute
+```
+watch kubectl get missions
+```
+
+Step 2: verify the the status of the deployed mission are shown correctly and automatically updated. Make sure the name of the edge cluster (B, B/C, B, C and D) and the status of the mission content(deployment/job) are shown in pairs.
+
+**Test Case 9: Update workload to edge clusters using mission**
+
+Continuing from the previous test case,
+
+Step 1: Note down the number of replicas of the deployment specified in the mission content of tests/edgecluster/data/missions/deployment-to-all.yaml
+
+Step 2: Change the number of deployment replicaset number in the mission content of tests/edgecluster/data/missions/deployment-to-all.yaml.
+
+Step 3: Run and verify the following command returns successfully
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 4:  run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the number of replicas in the deployment created via mission in each edge cluster is updated. 
+
+**Test Case 10: The mission status of a cluster is "cluster unreachable" if cluster disconnected**
+
+Continuing from the previous test case,
+
+Step 1: kill the edgecore process in cluster C and wait for 2 minutes. 
+
+Step 2: run the following command  
+```
+kubectl get missions
+```
+
+verify that:
+
+    a. the mission status of cluster B/C is "cluster unreachable" 
+
+    b. the status of the cluster under B/C, namely B/C/D, is cleared.
+
+**Test Case 11: Delete workload to edge clusters using mission**
+
+Continuing from the previous test case,
+
+Step 1: Run and verify the following command returns successfully
+```
+kubectl delete -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 2: run the following command  to verify the mission is deleted.
+```
+kubectl get missions
+```
+
+Step 3:  run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment specified in the mission content is gone in each edge cluster. 
+
+**Test Case 12: Deploy workload to an edge cluster with specific name**
+
+Step 1. update tests/edgecluster/data/missions/deployment-to-given-clusters.yaml to change the value of spec/placement/cluster/Name to be the name of cluster C.
+
+Step 2: Run and verify the following command returns successfully
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-given-clusters.yaml
+```
+
+Step 3: run the following command to verify the mission is deployed in cluster A, B, C and D, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster A, B, C and D respectively, 
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig]
+```
+
+Step 4: run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively, 
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment specified in the mission content is created in cluster C only. 
+
+Step 5: In the root operator machine, run command:
+```
+kubectl get mission 
+```
+Verify that the mission states of cluster B and B/C/D are reported as "not match", while the state of cluster B/C is the status info of the deployment.
+
+
+**Test Case 13: Deploy workload to selective edge clusters with given labels**
+
+Step 1. Double check the /etc/kubeedge/edgecore.yaml files in the cluster B, C and D and make sure only Cluster D has the label of "company" : "futurewei".
+
+Step 2: Run and verify the following command returns successfully
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-given-labels.yaml
+```
+
+Step 3: run the following command to verify the mission is deployed in cluster A, B, C and D, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster A, B, C and D respectively, 
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig]
+```
+
+Step 4: run the following command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively, 
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment is created in Cluster D only.
+
+Step 5: In the root operator machine, run command:
+```
+kubectl get mission 
+```
+Verify that the mission states of cluster B and B/C are reported as "not match", while the state of cluster B/C/D is the status info of the deployment.
+
+
+**Test Case 14: The information in the edge cluster status**
+
+Step 1: Run Command in the root operator machine
+```
+kubectl get edgeclusters
+```
+
+Verify the following information of edge cluster B are correctly displayed:
+
+a. LastHeartBeat 
+
+b. HealthStatus: should be "healthy"
+
+c. SubEdgeClusters: should include "C" and "C/D"
+
+d. Received_Missions
+
+e. Matched_Missions
+
+Step 2: Run Command in the root operator machine
+```
+kubectl get edgeclusters --kubeconfig=[Cluster_B_kubeconfig]
+```
+
+Verify the following information of edge cluster C are correctly displayed:
+
+a. LastHeartBeat 
+
+b. HealthStatus: should be "healthy"
+
+c. SubEdgeClusters: should include "D""
+
+d. Received_Missions
+
+e. Matched_Missions
+
+**Test Case 15: An edge cluster picks up the new mission added during its disconnection when reconnected to the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: delete all the missions deployed using command 
+```
+kubectl delete mission [mission_name]
+```
+
+And double check they are all gone using command
+```
+kubectl get missions
+```
+
+Step 2: kill the process of edgecore in cluster B. 
+
+Step 3: Run the following command and verify it returns successfully
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 4: run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the mission is **NOT** created in the edge clusters B, C and D. 
+
+
+Step 5: run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment specified in the mission content is **NOT** created in the edge clusters B, C and D. 
+
+Step 6: restart the edgecore in edge-cluster mode and wait 20 seconds
+```
+edgecore --edgecluster
+```
+
+Step 7:  run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the mission is created in the edge clusters B, C and D.  
+
+Step 8:  run command , with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the deployment specified in the mission content is created in the edge clusters B, C and D.  
+
+**Test Case 16: An edge cluster updates the mission updated during its disconnection when reconnected to the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: kill the process of edgecore in Cluster B. 
+
+Step 2: update the number of replicas in deployment spec in the mission content of tests/edgecluster/data/missions/deployment-to-all.yaml.
+
+Step 2: Run the following command and verify it returns successfully
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 4: run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig] -o json
+```
+Verify that the mission content is **NOT** updated in the edge clusters B, C and D.  
+
+
+Step 5: run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the replica number of the deployment created via mission is **NOT** updated  in the edge clusters B, C and D. 
+
+Step 6: restart the edgecore in edge-cluster mode in cluster B. Wait 20 seconds
+
+Step 7:  run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig] -o json
+```
+Verify that the mission content is updated in the edge clusters B, C and D. 
+
+Step 8:  run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the number of replicas in the deployment is updated in the edge clusters B, C and D. 
+
+
+**Test Case 17: An edge cluster deletes the mission deleted during its disconnection when reconnected to the cloud**
+
+Continuing from the previous test case, do the following:
+
+Step 1: kill the process of edgecore in cluster B. 
+ 
+Step 2: Run the following command and verify it returns successfully
+```
+kubectl delete -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+Step 4: run command , with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig] -o json
+```
+Verify that the mission content is **NOT** deleted in the edge clusters B, C and D.  
+
+
+Step 5: run command, with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the replica number of the deployment created via mission is still active in the edge clusters B, C and D. 
+
+Step 6: restart the edgecore in edge-cluster mode in cluster B and wait 20 seconds
+
+Step 7:  run command with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get missions --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the mission is deleted in the edge clusters B, C and D. 
+
+Step 8:  run command with [edge_cluster_kubeconfig] set to the kubeconfig files of cluster B, C and D respectively,
+```
+kubectl get deployment --kubeconfig=[edge_cluster_kubeconfig]
+```
+Verify that the the deployment created via mission is gone in the edge clusters B, C and D.  
+
+
+**Test Case 18: The mission content deleted in edge cluster will be re-instated**
+
+Step 1: Run the following command to deploy the mission
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+
+Step 2: run command verify the deployment specified in the mission is deployed in the edge cluster B
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Step 3:  run command to delete the deployment
+```
+kubectl delete deployment [deployment_name] --kubeconfig=[cluster_B_kubeconfig]
+```
+
+
+Step 4: verify the deployment specified in the mission is deleted (Note: do it immediately after the previous step)
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Step 8:  Wait 20 seconds, run command to verify the deployment specified in the mission is back
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+
+**Test Case 19: The mission content changed in edge cluster will be reverted automatically**
+
+Step 1: Run the following command to deploy the mission
+```
+kubectl apply -f tests/edgecluster/data/missions/deployment-to-all.yaml
+```
+
+
+Step 2: run command and verify the deployment specified in the mission is deployed in the edge cluster B
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Step 3:  run command to scale the deployment
+```
+kubectl scale deployment.v1.apps/[deployment_name] -rreplicas=10 --kubeconfig=[cluster_B_kubeconfig]
+```
+
+
+Step 4: verify the number of replicas in deployment specified in the mission is changed to 10 (Note: do it immediately after the previous step)
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+Step 8:  Wait 20 seconds, verify the number of the replicas in the deployment specified in the mission is reverted to the original value
+```
+kubectl get deployment --kubeconfig=[cluster_B_kubeconfig]
+```
+
+**Test Case 20: The status of edge cluster is "Unhealthy" if the clusterd is connected but the underlying cluster is unreachable**
+
+Step 1: Stop the arktos-up.sh script in cluster D.
+
+Step 2: make sure the edgecore in cluster D is still running
+
+step 3: Wait 20 seconds and check the "HealthStatus" of Cluster D in the output of the following command is "Unhealthy". 
+```
+kubectl get edgeclusters --kubeconfig=[cluster_C_kubeconfig]
+```
+
+step 4: Run the command in the root operator machine. 
+```
+kubectl get edgeclusters 
+```
+Verify the in the infor of EdgeCluster B, the state of SubEdgeCluster C/D is "unhealthy".

--- a/docs/fornax_test/test_clusters_setup.md
+++ b/docs/fornax_test/test_clusters_setup.md
@@ -1,0 +1,142 @@
+# Test Cluster Setup For 2021-8-30 Release Fornax End-to-End Test
+
+This doc describeds how to setup test clusters for the 2021-8-30 Fornax release test, whose test cases are given in the release_testplan.md in the same folder as this doc. 
+
+This test requires four clusters, denoted as A,B,C and D. A,B,C are kubernetes clusters created using kubeadm, while cluster D is an arktos cluster started by running script arktos-up.sh (https://github.com/CentaurusInfra/arktos/blob/master/hack/arktos-up.sh). These clusters are configured in a hierarchical topology, where Cluster B is an edge cluster to Cluster A, C edge to B, and D edge to C. 
+
+Machine A is referred as the "root operator machine" in these two docs.
+
+**Note: Run the commands in these two docs as a root user**
+
+## Machine Preparation
+
+1. Prepare 4 AWS machines, t2.xlarge, 80G storage, ubuntu 18.04, for the clusters of A, B, C and D.
+
+2. Open the port of 10000 & 10002 in the security group of of machine A, B and C.
+
+3. Open the port of 6443 in the security group of of machine A, B, C and D.
+
+4. In machine A, B, C, create a Kubernetes cluster following doc https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/.
+
+5. In machine D, clone the repo https://github.com/CentaurusInfra/arktos/ and start an Arktos cluster byt running the script arktos-up.sh.
+
+## Kubeedge Configuration
+
+### Kubeonfig File Preparation
+
+Copy the admin kubeconfig file of cluster A to machine B, the kubecofig file of cluster B to the machine of cluster C, and the kubeconfig file of cluster C to the machine of cluster D.
+
+Copy the kubeconfig files of cluster A, B, C and D to the root operator machine.
+
+### In machine A, do the following
+
+
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+
+Build the binaries of edgecore and cloudcore using the commands
+```
+make WHAT=cloudcore
+make WHAT=edgecore
+```
+
+2. config cloudcore 
+```
+cp /etc/kubernetes/admin.conf /root/.kube/config
+_output/local/bin/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
+```
+3. Generate security data 
+
+Note down the IP address of machine A, B, C, and D, denotes as IP_A, IP_B, IP_C and IP_D, and run the command:
+
+```
+build/tools/certgen.sh genCA IP_A IP_B IP_C IP_D
+build/tools/certgen.sh genCertAndKey server IP_A IP_B IP_C IP_D
+```
+
+Then copy the files of folder /etc/kubeedge/ca and /etc/kubeedge/certs in machine A to the folder of /etc/kubeedge/ca and /etc/kubeedge/certs in machine B, C and D. 
+
+5. Install CRDs
+```
+export KUBECONFIG=[Cluster_A_kubeconfig_file]
+
+kubectl apply -f build/crds/devices/devices_v1alpha2_device.yaml
+kubectl apply -f build/crds/devices/devices_v1alpha2_devicemodel.yaml 
+
+kubectl apply -f build/crds/reliablesyncs/cluster_objectsync_v1alpha1.yaml
+kubectl apply -f build/crds/reliablesyncs/objectsync_v1alpha1.yaml 
+
+kubectl apply -f  build/crds/router/router_v1_rule.yaml
+kubectl apply -f  build/crds/router/router_v1_ruleEndpoint.yaml
+
+kubectl apply -f build/crds/edgecluster/mission_v1.yaml
+kubectl apply -f build/crds/edgecluster/edgecluster_v1.yaml
+
+```
+
+
+### In machine B
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+
+Build the binaries of edgecore and cloudcore using the commands
+```
+make WHAT=cloudcore
+make WHAT=edgecore
+```
+
+2. config cloudcore 
+```
+cp /etc/kubernetes/admin.conf /root/.kube/config
+_output/local/bin/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
+```
+3. config edgecore
+```
+cp [Cluster_B_kubeconfig_file] /root/edgecluster.kubeconfig
+_output/local/bin/edgecore --edgeclusterconfig > /etc/kubeedge/config/edgecore.yaml
+tests/edgecluster/hack/update_edgecore_config.sh [cluster_A_kubeconfig_file]
+```
+
+### In machine C
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+
+Build the binaries of edgecore and cloudcore using the commands
+```
+make WHAT=cloudcore
+make WHAT=edgecore
+```
+
+2. config cloudcore 
+```
+cp /etc/kubernetes/admin.conf /root/.kube/config
+_output/local/bin/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
+```
+3. config edgecore
+```
+cp [Cluster_C_kubeconfig_file] /root/edgecluster.kubeconfig
+_output/local/bin/edgecore --edgeclusterconfig > /etc/kubeedge/config/edgecore.yaml
+tests/edgecluster/hack/update_edgecore_config.sh [cluster_B_kubeconfig_file]
+```
+
+### In machine D
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+
+Build the binary of edgecore 
+```
+make WHAT=edgecore
+```
+
+2. config edgecore
+```
+cp [Cluster_D_kubeconfig_file] /root/edgecluster.kubeconfig
+_output/local/bin/edgecore --edgeclusterconfig > /etc/kubeedge/config/edgecore.yaml
+tests/edgecluster/hack/update_edgecore_config.sh [cluster_C_kubeconfig_file]
+```
+
+update the /etc/kubeedge/config/edgecore.yaml so the section of spec/clusterd looks like the following:
+
+```
+  clusterd:
+    ...
+    kubeDistro: arktos
+    labels:
+      "company" : "futurewei"
+```

--- a/docs/fornax_test/test_clusters_setup.md
+++ b/docs/fornax_test/test_clusters_setup.md
@@ -31,7 +31,7 @@ Copy the kubeconfig files of cluster A, B, C and D to the root operator machine.
 ### In machine A, do the following
 
 
-1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to the branch/commit to test.
 
 Build the binaries of edgecore and cloudcore using the commands
 ```
@@ -75,7 +75,7 @@ kubectl apply -f build/crds/edgecluster/edgecluster_v1.yaml
 
 
 ### In machine B
-1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to the branch/commit to test.
 
 Build the binaries of edgecore and cloudcore using the commands
 ```
@@ -96,7 +96,7 @@ tests/edgecluster/hack/update_edgecore_config.sh [cluster_A_kubeconfig_file]
 ```
 
 ### In machine C
-1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to the branch/commit to test.
 
 Build the binaries of edgecore and cloudcore using the commands
 ```
@@ -117,7 +117,7 @@ tests/edgecluster/hack/update_edgecore_config.sh [cluster_B_kubeconfig_file]
 ```
 
 ### In machine D
-1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to latest version of main branch.
+1. Clone a repo of https://github.com/CentaurusInfra/fornax, sync to the branch/commit to test.
 
 Build the binary of edgecore 
 ```

--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -53,6 +53,7 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			verflag.PrintAndExitIfRequested()
 			flag.PrintMinConfigAndExitIfRequested(v1alpha1.NewMinEdgeCoreConfig())
 			flag.PrintDefaultConfigAndExitIfRequested(v1alpha1.NewDefaultEdgeCoreConfig())
+			flag.PrintEdgeClusterConfigAndExitIfRequested(v1alpha1.NewEdgeClusterEdgeCoreConfig())
 			flag.PrintFlags(cmd.Flags())
 
 			if errs := opts.Validate(); len(errs) > 0 {

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -196,6 +196,7 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 		},
 		Modules: &Modules{
 			CloudHub: &CloudHub{
+				Enable:            true,
 				NodeLimit:         1000,
 				TLSCAFile:         constants.DefaultCAFile,
 				TLSCAKeyFile:      constants.DefaultCAKeyFile,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -237,3 +237,48 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 		},
 	}
 }
+
+// NewEdgeClusterEdgeCoreConfig returns a common EdgeCoreConfig object
+func NewEdgeClusterEdgeCoreConfig() *EdgeCoreConfig {
+	hostnameOverride, err := os.Hostname()
+	if err != nil {
+		hostnameOverride = constants.DefaultHostnameOverride
+	}
+	localIP, _ := util.GetLocalIP(hostnameOverride)
+	return &EdgeCoreConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       Kind,
+			APIVersion: path.Join(GroupName, APIVersion),
+		},
+		DataBase: &DataBase{
+			DataSource: DataBaseDataSource,
+		},
+		Modules: &Modules{
+			Clusterd: &Clusterd{
+				Enable:     true,
+				Kubeconfig: "/root/edgecluster.kubeconfig",
+				KubeDistro: "k8s",
+				NodeIP:     localIP,
+			},
+			EdgeHub: &EdgeHub{
+				Enable:            true,
+				Heartbeat:         15,
+				TLSCAFile:         constants.DefaultCAFile,
+				TLSCertFile:       constants.DefaultCertFile,
+				TLSPrivateKeyFile: constants.DefaultKeyFile,
+				WebSocket: &EdgeHubWebSocket{
+					Enable:           true,
+					HandshakeTimeout: 30,
+					ReadDeadline:     15,
+					Server:           net.JoinHostPort(localIP, "10000"),
+					WriteDeadline:    15,
+				},
+				HTTPServer: (&url.URL{
+					Scheme: "https",
+					Host:   net.JoinHostPort(localIP, "10002"),
+				}).String(),
+				Token: "",
+			},
+		},
+	}
+}

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -74,10 +74,12 @@ func Config(name string, value ConfigValue, usage string) *ConfigValue {
 
 const minConfigFlagName = "minconfig"
 const defaultConfigFlagName = "defaultconfig"
+const edgeclusterConfigFlagName = "edgeclusterconfig"
 
 var (
-	minConfigFlag     = Config(minConfigFlagName, ConfigFalse, "Print min configuration for reference, users can refer to it to create their own configuration files, it is suitable for beginners.")
-	defaultConfigFlag = Config(defaultConfigFlagName, ConfigFalse, "Print default configuration for reference, users can refer to it to create their own configuration files, it is suitable for advanced users.")
+	minConfigFlag         = Config(minConfigFlagName, ConfigFalse, "Print min configuration for reference, users can refer to it to create their own configuration files, it is suitable for beginners.")
+	defaultConfigFlag     = Config(defaultConfigFlagName, ConfigFalse, "Print default configuration for reference, users can refer to it to create their own configuration files, it is suitable for advanced users.")
+	edgeclusterConfigFlag = Config(edgeclusterConfigFlagName, ConfigFalse, "Print edgecluster configuration for reference, users can refer to it to create their own configuration files, it is suitable for advanced users.")
 )
 
 // AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
@@ -85,6 +87,7 @@ var (
 func AddFlags(fs *pflag.FlagSet) {
 	fs.AddFlag(pflag.Lookup(minConfigFlagName))
 	fs.AddFlag(pflag.Lookup(defaultConfigFlagName))
+	fs.AddFlag(pflag.Lookup(edgeclusterConfigFlagName))
 }
 
 // PrintMinConfigAndExitIfRequested will check if the -minconfig flag was passed
@@ -116,6 +119,22 @@ func PrintDefaultConfigAndExitIfRequested(config interface{}) {
 		fmt.Println("# With --defaultconfig flag, users can easily get a default full config file as reference, with all fields (and field descriptions) included and default values set. ")
 		fmt.Println("# Users can modify/create their own configs accordingly as reference. ")
 		fmt.Println("# Because it is a full configuration, it is more suitable for advanced users.")
+		fmt.Printf("\n%v\n\n", string(data))
+		os.Exit(0)
+	}
+}
+
+// PrintEdgeClusterConfigAndExitIfRequested will check if the -edgeclusterconfig flag was passed
+// and, if so, print the default edgecluster config and exit.
+func PrintEdgeClusterConfigAndExitIfRequested(config interface{}) {
+	if *edgeclusterConfigFlag == ConfigTrue {
+		data, err := yaml.Marshal(config)
+		if err != nil {
+			fmt.Printf("Marshal default config to yaml error %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("# With --edgeclusterConfigFlag flag, users can easily get a edgecluster config as reference. ")
+		fmt.Println("# Users can modify/create their own configs accordingly as reference. ")
 		fmt.Printf("\n%v\n\n", string(data))
 		os.Exit(0)
 	}

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -77,9 +77,9 @@ const defaultConfigFlagName = "defaultconfig"
 const edgeclusterConfigFlagName = "edgeclusterconfig"
 
 var (
-	minConfigFlag         = Config(minConfigFlagName, ConfigFalse, "Print min configuration for reference, users can refer to it to create their own configuration files, it is suitable for beginners.")
-	defaultConfigFlag     = Config(defaultConfigFlagName, ConfigFalse, "Print default configuration for reference, users can refer to it to create their own configuration files, it is suitable for advanced users.")
-	edgeclusterConfigFlag = Config(edgeclusterConfigFlagName, ConfigFalse, "Print edgecluster configuration for reference, users can refer to it to create their own configuration files, it is suitable for advanced users.")
+	minConfigFlag         = Config(minConfigFlagName, ConfigFalse, "Print min configuration for reference. Users can refer to it to create their own configuration files. It is suitable for beginners.")
+	defaultConfigFlag     = Config(defaultConfigFlagName, ConfigFalse, "Print default configuration for reference. Users can refer to it to create their own configuration files. It is suitable for advanced users.")
+	edgeclusterConfigFlag = Config(edgeclusterConfigFlagName, ConfigFalse, "Print edgecluster configuration for reference. Users can refer to it to create their own configuration files. It is suitable for advanced users.")
 )
 
 // AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the

--- a/tests/edgecluster/hack/update_edgecore_config.sh
+++ b/tests/edgecluster/hack/update_edgecore_config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# THis is a tool to update /etc/kubeedge/config/edgecore.yaml to work with a cloudcore whose kubeconfig file is specified in the command line
+
+set -e
+
+KUBECONFIG_FILE=$1
+
+if [ -z "${KUBECONFIG_FILE}" ]; then 
+    echo "Please specify the kubeconfig file to access the cloud cluster"
+    exit
+fi
+
+if [ ! -f "${KUBECONFIG_FILE}" ]; then
+    echo "kubeconfig file (${KUBECONFIG_FILE}) not found!"
+    exit
+fi
+
+TARGET_FILE="/etc/kubeedge/config/edgecore.yaml"
+
+IP_ADDRESS=$(grep server "${KUBECONFIG_FILE}" | awk -F "/" '{print $3}' | awk -F ":" '{print $1}')
+
+TOKEN=$(kubectl get secret -nkubeedge tokensecret --kubeconfig "${KUBECONFIG_FILE}" -o=jsonpath='{.data.tokendata}' | base64 -d)
+
+TOKEN_LINE="    token: \"${TOKEN}\""
+
+sed -i "s/    token:.*/${TOKEN_LINE}/" ${TARGET_FILE}
+
+SERVER_LINE="      server: ${IP_ADDRESS}:10000"
+
+sed -i "s/      server:.*/${SERVER_LINE}/" ${TARGET_FILE}
+
+HTTPSERVER_LINE="    httpServer: ${IP_ADDRESS}:10002"
+
+sed -i "s/    httpServer:.*/${HTTPSERVER_LINE}/" ${TARGET_FILE}


### PR DESCRIPTION
This PR presents the 8-30 release end-to-end test plan. The docs include detailed instructions on test environment setup and test case procedures.

Also included in this PR are some code changes and improvement about the test environment setup. In details, they are:
1. Add a commandline option "--edgeclusterconfig" to the binary "edgecore", to create the config file when setting up edge cluster.
2. Update certgen.sh to create certificates that will be used in multiple clusters
3. create a update_edgecore_config.sh to help update edgecore.yaml for edgecluster setup
4. simplify the output of command of "kubectl get edgecluster" for a better presentation