### PR TITLE
report mission/edgecluster status correctly when the cluster is unrea…

### DIFF
--- a/build/crds/edgecluster/edgecluster_v1.yaml
+++ b/build/crds/edgecluster/edgecluster_v1.yaml
@@ -21,10 +21,10 @@ spec:
     - name: LastHearbeat
       type: date
       JSONPath: .status.lastheartbeat
-    - name: Healthy
+    - name: HealthStatus
       type: string
       description: Whether the cluster is healthy and accessible
-      JSONPath: .status.healthy
+      JSONPath: .status.healthstatus
     - name: Nodes
       type: string
       description: nodes
@@ -35,9 +35,9 @@ spec:
     - name: EdgeClusters
       type: string
       JSONPath: .status.edgeclusters
-    - name: ReceivedMissions
+    - name: Received_Missions
       type: string
       JSONPath: .status.receivedmissions
-    - name: MatchedMissions
+    - name: Matched_Missions
       type: string
       JSONPath: .status.activemissions

--- a/build/crds/edgecluster/edgecluster_v1.yaml
+++ b/build/crds/edgecluster/edgecluster_v1.yaml
@@ -22,7 +22,7 @@ spec:
       type: date
       JSONPath: .status.lastheartbeat
     - name: Healthy
-      type: boolean
+      type: string
       description: Whether the cluster is healthy and accessible
       JSONPath: .status.healthy
     - name: Nodes

--- a/cloud/pkg/apis/edgeclusters/v1/types.go
+++ b/cloud/pkg/apis/edgeclusters/v1/types.go
@@ -100,7 +100,7 @@ type EdgeClusterSpec struct {
 
 // EdgeClusterStatus is a description of Mission status
 type EdgeClusterStatus struct {
-	Healthy string `json:"healthy,omitempty"`
+	HealthStatus string `json:"healthstatus,omitempty"`
 
 	EdgeClusters []string `json:"edgeclusters,omitempty"`
 

--- a/cloud/pkg/apis/edgeclusters/v1/types.go
+++ b/cloud/pkg/apis/edgeclusters/v1/types.go
@@ -100,7 +100,7 @@ type EdgeClusterSpec struct {
 
 // EdgeClusterStatus is a description of Mission status
 type EdgeClusterStatus struct {
-	Healthy bool `json:"healthy,omitempty"`
+	Healthy string `json:"healthy,omitempty"`
 
 	EdgeClusters []string `json:"edgeclusters,omitempty"`
 

--- a/cloud/pkg/missionstatepruner/pruner.go
+++ b/cloud/pkg/missionstatepruner/pruner.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	EdgeClusterOffline = "cluster unreacheable"
+	HealthyStatus      = "healthy"
 )
 
 //Mission state pruner periodically update the mission state when some edgeclusters become offline
@@ -76,7 +77,7 @@ func (msp *MissionStatePruner) checkAndPrune() {
 	deadEdgeClusters := map[string]bool{}
 	newDeadEdgeClusters := false
 	for _, ec := range allEdgeClusters.Items {
-		if time.Since(ec.Status.LastHeartBeat.Time) > msp.edgeclusterTimeout || ec.Status.Healthy != "healthy" {
+		if time.Since(ec.Status.LastHeartBeat.Time) > msp.edgeclusterTimeout || ec.Status.HealthStatus != HealthyStatus {
 			deadEdgeClusters[ec.Name] = true
 			if _, ok := msp.deadEdgeClustersCache[ec.Name]; !ok {
 				newDeadEdgeClusters = true

--- a/cloud/pkg/missionstatepruner/pruner.go
+++ b/cloud/pkg/missionstatepruner/pruner.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EdgeClusterOffline = "cluster offline"
+	EdgeClusterOffline = "cluster unreacheable"
 )
 
 //Mission state pruner periodically update the mission state when some edgeclusters become offline
@@ -76,7 +76,7 @@ func (msp *MissionStatePruner) checkAndPrune() {
 	deadEdgeClusters := map[string]bool{}
 	newDeadEdgeClusters := false
 	for _, ec := range allEdgeClusters.Items {
-		if time.Since(ec.Status.LastHeartBeat.Time) > msp.edgeclusterTimeout {
+		if time.Since(ec.Status.LastHeartBeat.Time) > msp.edgeclusterTimeout || ec.Status.Healthy != "healthy" {
 			deadEdgeClusters[ec.Name] = true
 			if _, ok := msp.deadEdgeClustersCache[ec.Name]; !ok {
 				newDeadEdgeClusters = true

--- a/edge/pkg/clusterd/edgecluster_status_reporter.go
+++ b/edge/pkg/clusterd/edgecluster_status_reporter.go
@@ -41,6 +41,8 @@ import (
 const (
 	MissionCrdFile     = "mission_v1.yaml"
 	EdgeClusterCrdFile = "edgecluster_v1.yaml"
+	HealthyStatus      = "healthy"
+	UnreachableStatus  = "unreachable"
 )
 
 var initEdgeCluster edgeclustersv1.EdgeCluster
@@ -157,7 +159,7 @@ func (esr *EdgeClusterStatusReporter) getEdgeClusterStatusRequest(edgeCluster *e
 	clusterHealthy := helper.TestClusterReady()
 
 	if clusterHealthy {
-		edgeClusterStatus.Status.Healthy = "healthy"
+		edgeClusterStatus.Status.HealthStatus = HealthyStatus
 		edgeClusterStatus.Status.EdgeClusters = helper.GetLocalClusterScopeResourceNames("edgeclusters", "")
 		edgeClusterStatus.Status.Nodes = helper.GetLocalClusterScopeResourceNames("nodes", "")
 		edgeClusterStatus.Status.EdgeNodes = helper.GetLocalClusterScopeResourceNames("nodes", "node-role.kubernetes.io/edge")
@@ -174,7 +176,7 @@ func (esr *EdgeClusterStatusReporter) getEdgeClusterStatusRequest(edgeCluster *e
 		edgeClusterStatus.Status.ReceivedMissions = receivedMissions
 		edgeClusterStatus.Status.ActiveMissions = matchededMissions
 	} else {
-		edgeClusterStatus.Status.Healthy = "unreachable"
+		edgeClusterStatus.Status.HealthStatus = UnreachableStatus
 		edgeClusterStatus.Status.EdgeClusters = []string{}
 		edgeClusterStatus.Status.Nodes = []string{}
 		edgeClusterStatus.Status.EdgeNodes = []string{}


### PR DESCRIPTION
This PR fixes the issue that mission/edgecluster status are not correctly reported when the underlying edgecluster is not long responding but clusterd is working. The existing code only handles the cases where the clusterd cannot reach the cloud.

Before this change, if the connection between clusterd and cloud is OK, but the apiserver in the edgecluster is not longer responding, "kubectl get edgecluster" and "kubectl get missions" will get the following outputs, which are really confusing to the end users:

![image](https://user-images.githubusercontent.com/51831990/127937749-1dd7fca1-de37-4f3b-8a33-a1eaffc9ddd9.png)


With this PR, the end user will see the following for the commands "kubectl get edgecluster" and "kubectl get missions" when the under cluster is not reachable. 
![image](https://user-images.githubusercontent.com/51831990/127937762-fb9f4a0d-9c60-48eb-b069-4a8c8c731b69.png)
