### PR TITLE
fix mission label issue

### DIFF
--- a/build/crds/edgecluster/mission_v1.yaml
+++ b/build/crds/edgecluster/mission_v1.yaml
@@ -40,13 +40,6 @@ spec:
                     type: object
                 matchlabels:
                   type: object
-                  additionalProperties:
-                    type: object
-                    properties:
-                      code:
-                        type: string
-                      text:
-                        type: string
             statecheck:
               type: object
               properties:

--- a/tests/edgecluster/data/missions/deployment-to-given-labels.yaml
+++ b/tests/edgecluster/data/missions/deployment-to-given-labels.yaml
@@ -4,8 +4,8 @@ metadata:
   name: deployment-to-label-smart
 spec:
   placement:    
-    matchLabels:
-      smart_edge: true
+    matchlabels:
+      "company" : "futurewei"
   content: |
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
This PR fixed issue https://github.com/CentaurusInfra/fornax/issues/33.

It is verified that with this change, the mission content will only be deployed to the given edge clusters with the specific label.