### PR TITLE
Fixed the broken keadm e2e task

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -119,7 +119,7 @@ func installCRDs(ks *K8SInstTool) error {
 		"router": {"router/router_v1_rule.yaml",
 			"router/router_v1_ruleEndpoint.yaml"},
 	}
-	//version := fmt.Sprintf("%d.%d", ks.ToolVersion.Major, ks.ToolVersion.Minor)
+	//TODO: There is an api version change in the latest version 1.9.0 to break CI/CD. This is a temp solution to roll back the api version change.
 	version := "1.8"
 	CRDDownloadURL := fmt.Sprintf(KubeEdgeCRDDownloadURL, version)
 	for dir := range crds {

--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -119,7 +119,8 @@ func installCRDs(ks *K8SInstTool) error {
 		"router": {"router/router_v1_rule.yaml",
 			"router/router_v1_ruleEndpoint.yaml"},
 	}
-	version := fmt.Sprintf("%d.%d", ks.ToolVersion.Major, ks.ToolVersion.Minor)
+	//version := fmt.Sprintf("%d.%d", ks.ToolVersion.Major, ks.ToolVersion.Minor)
+	version := "1.7"
 	CRDDownloadURL := fmt.Sprintf(KubeEdgeCRDDownloadURL, version)
 	for dir := range crds {
 		crdPath := KubeEdgeCrdPath + "/" + dir

--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -120,7 +120,7 @@ func installCRDs(ks *K8SInstTool) error {
 			"router/router_v1_ruleEndpoint.yaml"},
 	}
 	//version := fmt.Sprintf("%d.%d", ks.ToolVersion.Major, ks.ToolVersion.Minor)
-	version := "1.7"
+	version := "1.8"
 	CRDDownloadURL := fmt.Sprintf(KubeEdgeCRDDownloadURL, version)
 	for dir := range crds {
 		crdPath := KubeEdgeCrdPath + "/" + dir


### PR DESCRIPTION
The keadm installer tends to download crd files from kube edge NOT Fornax. 

Please refer to https://github.com/CentaurusInfra/fornax/blob/main/keadm/cmd/keadm/app/cmd/util/common.go#L69. It used to work until there is a new version v1.9.0 added to https://kubeedge.io/latestversion. For the version v1.9.0,  there is a change https://github.com/kubeedge/kubeedge/commit/c39927ef74176e5f79b78d80d4c312f7d5b9d7dd#diff-37aa47f76f3a524adab02885d1b0deaade11da7c00eee11a4b0e1486e7015b67 which updated apiVersion: apiextensions.k8s.io/v1beta1 to  apiVersion: apiextensions.k8s.io/v1.

A temp solution is changing v1.9.0 to v1.8 which does not have the apiVersion change.

If we updated the wrong KubeEdgeCRDDownloadURL to our Fornax repo, there will be other issues caused by incomplete Fornax code changes, such as unmarshall tfjobCRD.


