### PR TITLE
Added all the command parameters to a config file

### DIFF
--- a/cloud/cmd/config/gateway_agent_config.go
+++ b/cloud/cmd/config/gateway_agent_config.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2022 The KubeEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package config
 
 import (
@@ -28,7 +12,7 @@ type GatewayAgentConfiguration struct {
 	RemoteGateways []RemoteGateway
 	LocalDividerIP string
 	GenevePort     int
-	LogLevel       int
+	LogLevel       string
 }
 
 type RemoteGateway struct {
@@ -43,7 +27,6 @@ func NewGatewayConfiguration(fileName string) (GatewayAgentConfiguration, error)
 		return configuration, fmt.Errorf("failed to open the given config file %s", fileName)
 	}
 	filepath := path.Join(path.Dir(runningfile), fileName)
-	fmt.Println(filepath)
 	file, err := os.Open(filepath)
 	if err != nil {
 		return configuration, err

--- a/cloud/cmd/config/gateway_agent_config_test.go
+++ b/cloud/cmd/config/gateway_agent_config_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+)
+
+func TestRemoteGateway(t *testing.T) {
+	receivedData := []string{
+		`{
+			"RemoteGateways": [
+				{
+					"RemoteGatewayIP": "1.0.0.1",
+					"RemoteGatewayPort": 800
+				}
+			],
+			"LogLevel": "3"
+		}`,
+		`{
+			"RemoteGateways": [
+				{
+					"RemoteGatewayIP": "2.0.0.1",
+					"RemoteGatewayPort": 800
+				},
+				{
+					"RemoteGatewayIP": "172.15.2.3",
+					"RemoteGatewayPort": 6081
+				}
+			],
+			"LogLevel": "1"
+		}`,
+		`{
+			"RemoteGateways": [
+				{
+					"RemoteGatewayIP": "1.0.0.1",
+					"RemoteGatewayPort": 800
+				}
+			],
+			"GenevePort": 100,
+			"LogLevel": "3"
+		}`,
+		`{
+			"RemoteGateways": [
+				{
+					"RemoteGatewayIP": "1.0.0.1",
+					"RemoteGatewayPort": 800
+				}
+			],
+			"GenevePort": 100,
+			"LocalDividerIP": "127.0.0.1",
+			"LogLevel": "3"
+		}`,
+	}
+
+	expectedConfigs := []GatewayAgentConfiguration{
+		{
+			RemoteGateways: []RemoteGateway{
+				{RemoteGatewayIP: "1.0.0.1", RemoteGatewayPort: 800},
+			},
+			LogLevel: "3",
+		},
+		{
+			RemoteGateways: []RemoteGateway{
+				{RemoteGatewayIP: "2.0.0.1", RemoteGatewayPort: 800},
+				{RemoteGatewayIP: "172.15.2.3", RemoteGatewayPort: 6081},
+			},
+			LogLevel: "1",
+		},
+		{
+			RemoteGateways: []RemoteGateway{
+				{RemoteGatewayIP: "1.0.0.1", RemoteGatewayPort: 800},
+			},
+			GenevePort: 100,
+			LogLevel:   "3",
+		},
+		{
+			RemoteGateways: []RemoteGateway{
+				{RemoteGatewayIP: "1.0.0.1", RemoteGatewayPort: 800},
+			},
+			GenevePort:     100,
+			LocalDividerIP: "127.0.0.1",
+			LogLevel:       "3",
+		},
+	}
+
+	for i, data := range receivedData {
+		received := GatewayAgentConfiguration{}
+		err := json.Unmarshal([]byte(data), &received)
+		if err != nil {
+			log.Fatal(err)
+		}
+		assertEquals(received, expectedConfigs[i], t)
+	}
+}
+
+func assertEquals(received, expected GatewayAgentConfiguration, t *testing.T) {
+	if len(received.RemoteGateways) != len(expected.RemoteGateways) {
+		t.Errorf("Received %d gateway config, expected %d gateway config", len(received.RemoteGateways), len(expected.RemoteGateways))
+	}
+	for i, gateway := range received.RemoteGateways {
+		if gateway.RemoteGatewayIP != expected.RemoteGateways[i].RemoteGatewayIP {
+			t.Errorf("Received %s gateway ip, expected %s gateway ip", gateway.RemoteGatewayIP, expected.RemoteGateways[i].RemoteGatewayIP)
+		}
+		if gateway.RemoteGatewayPort != expected.RemoteGateways[i].RemoteGatewayPort {
+			t.Errorf("Received %d gateway port, expected %d gateway port", gateway.RemoteGatewayPort, expected.RemoteGateways[i].RemoteGatewayPort)
+		}
+	}
+	if received.LocalDividerIP != expected.LocalDividerIP {
+		t.Errorf("Received %s local divider ip, expected %s local divider ip", received.LocalDividerIP, expected.LocalDividerIP)
+	}
+	if received.GenevePort != expected.GenevePort {
+		t.Errorf("Received %d geneve port, expected %d geneve port", received.GenevePort, expected.GenevePort)
+	}
+	if received.LogLevel != expected.LogLevel {
+		t.Errorf("Received %s log level, expected %s local log level", received.LogLevel, expected.LogLevel)
+	}
+}

--- a/cloud/cmd/inter_cluster_gateway/config/gateway_agent_config.go
+++ b/cloud/cmd/inter_cluster_gateway/config/gateway_agent_config.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+)
+
+type GatewayAgentConfiguration struct {
+	RemoteGateways []RemoteGateway
+	LocalDividerIP string
+	GenevePort     int
+	LogLevel       int
+}
+
+type RemoteGateway struct {
+	RemoteGatewayIP   string
+	RemoteGatewayPort int
+}
+
+func NewGatewayConfiguration(fileName string) (GatewayAgentConfiguration, error) {
+	_, runningfile, _, ok := runtime.Caller(1)
+	configuration := GatewayAgentConfiguration{}
+	if !ok {
+		return configuration, fmt.Errorf("failed to open the given config file %s", fileName)
+	}
+	filepath := path.Join(path.Dir(runningfile), fileName)
+	fmt.Println(filepath)
+	file, err := os.Open(filepath)
+	if err != nil {
+		return configuration, err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+
+	err = decoder.Decode(&configuration)
+	return configuration, err
+}

--- a/cloud/cmd/inter_cluster_gateway/gateway_config.json
+++ b/cloud/cmd/inter_cluster_gateway/gateway_config.json
@@ -7,5 +7,5 @@
     ],
     "GenevePort": 6081,
     "LocalDividerIP": "172.31.15.85",
-    "LogLevel": 3
+    "LogLevel": "3"
 }

--- a/cloud/cmd/inter_cluster_gateway/gateway_config.json
+++ b/cloud/cmd/inter_cluster_gateway/gateway_config.json
@@ -1,0 +1,11 @@
+{
+    "RemoteGateways": [ 
+        {   
+            "RemoteGatewayIP": "172.31.15.238", 
+            "RemoteGatewayPort": 2615
+        }
+    ],
+    "GenevePort": 6081,
+    "LocalDividerIP": "172.31.15.85",
+    "LogLevel": 3
+}

--- a/cloud/cmd/inter_cluster_gateway/main.go
+++ b/cloud/cmd/inter_cluster_gateway/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/routing"
-	"github.com/kubeedge/kubeedge/cloud/cmd/inter_cluster_gateway/config"
+	cmdconfig "github.com/kubeedge/kubeedge/cloud/cmd/config"
 	"k8s.io/klog/v2"
 )
 
@@ -41,13 +41,12 @@ var (
 
 // initialize the commandline options
 func InitFlag() {
-	config, err := config.NewGatewayConfiguration("gateway_config.json")
+	config, err := cmdconfig.NewGatewayConfiguration("gateway_config.json")
 	if err != nil {
-		fmt.Printf("error setting gateway agent configuration: %v", err)
-		os.Exit(1)
+		panic(fmt.Errorf("error setting gateway agent configuration: %v", err))
 	}
 
-	logLevel = string(config.LogLevel)
+	logLevel = config.LogLevel
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
 	err = local.Set("v", logLevel)
@@ -112,9 +111,6 @@ func init() {
 
 func main() {
 	defer handle.Close()
-
-	version := pcap.Version()
-	fmt.Println(version)
 
 	geneveFilter := fmt.Sprintf("port %d", genevePort)
 	if err := handle.SetBPFFilter(geneveFilter); err != nil {

--- a/cloud/cmd/inter_cluster_gateway/main.go
+++ b/cloud/cmd/inter_cluster_gateway/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/routing"
-        "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/cloud/cmd/config"
 )

--- a/cloud/cmd/inter_cluster_gateway/main.go
+++ b/cloud/cmd/inter_cluster_gateway/main.go
@@ -12,8 +12,9 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/routing"
-	cmdconfig "github.com/kubeedge/kubeedge/cloud/cmd/config"
-	"k8s.io/klog/v2"
+        "k8s.io/klog/v2"
+
+	"github.com/kubeedge/kubeedge/cloud/cmd/config"
 )
 
 var (
@@ -41,7 +42,7 @@ var (
 
 // initialize the commandline options
 func InitFlag() {
-	config, err := cmdconfig.NewGatewayConfiguration("gateway_config.json")
+	config, err := config.NewGatewayConfiguration("gateway_config.json")
 	if err != nil {
 		panic(fmt.Errorf("error setting gateway agent configuration: %v", err))
 	}


### PR DESCRIPTION
The origin design of gateway agent is to hard-code some information in the main.go and pass other parameters using command line.

The change is to add a configuration json file for the gateway agent.

### Verification

#### Step 1

Start two mizar clusters, each cluster contains a host as the **cluster gateway**, where there are bouncers/dividers deployed. Both clusters share the same VPC, “vpc1“. Cluster A is assigned the subnet 192.168.122.#, and cluster B is assigned the subnet of 192.168.0.#.

Cluster A (192.168.**122**.0/24):
```
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get vpcs
NAME   IP            PREFIX   VNI        DIVIDERS   STATUS        CREATETIME                   PROVISIONDELAY
vpc0   20.0.0.0      8        1          1          Provisioned   2022-01-25T20:43:39.815395   42.623736
vpc1   192.168.0.0   16       11109972   1          Provisioned
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get subnets
NAME   IP              PREFIX   VNI        VPC    STATUS        VIRTUAL   BOUNCERS   CREATETIME                   PROVISIONDELAY
net0   20.0.0.0        8        1          vpc0   Provisioned   false     1          2022-01-25T20:43:39.925369   62.726174
net1   192.168.0.0     24       11109972   vpc1   Provisioned   true      1
net2   192.168.122.0   24       11109972   vpc1   Provisioned   false     1
```
Cluster B (192.168.**0**.0/24):
```
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl get vpcs
NAME   IP            PREFIX   VNI        DIVIDERS   STATUS        CREATETIME                   PROVISIONDELAY
vpc0   20.0.0.0      8        1          1          Provisioned   2022-01-25T20:34:48.265420   42.496971
vpc1   192.168.0.0   16       11109972   1          Provisioned
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl get subnets
NAME   IP              PREFIX   VNI        VPC    STATUS        VIRTUAL   BOUNCERS   CREATETIME                   PROVISIONDELAY
net0   20.0.0.0        8        1          vpc0   Provisioned   false     1          2022-01-25T20:34:48.356836   62.769122
net1   192.168.0.0     24       11109972   vpc1   Provisioned   false     1
net2   192.168.122.0   24       11109972   vpc1   Provisioned   true      1
```
Please verify that all the vpcs have the same vni 11109972  across clusters1
Cluster A has a virtual subnet net1  192.168.0.0/24 which is a local subnet net1 in cluster B
Cluster B has a virtual subnet net2 192.168.122.0/24 which is a local subnet net2 in cluster A

Also, please verify that gateway config has been added to configmap
Cluster A (192.168.**122**.0/24):
```
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get configmap  cluster-gateway-config -o json
{
    "apiVersion": "v1",
    "data": {
        "gateway_host_ip": "172.31.15.208"
    },
    "kind": "ConfigMap",
```
Cluster B (192.168.**0**.0/24):
```
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl get configmap  cluster-gateway-config -o json
{
    "apiVersion": "v1",
    "data": {
        "gateway_host_ip": "172.31.15.238"
    },
    "kind": "ConfigMap",
```
The gateway is 172.31.15.208 in cluster A and the gateway is 172.31.15.238 in cluster B

#### Step 2
Clone the fornax repo in 2 gateway hosts
```
git clone https://github.com/CentaurusInfra/fornax.git
```
Build the gateway agents
```
root@ip-172-31-15-208:/home/ubuntu/fornax/cloud/cmd/inter_cluster_gateway# go build  -o gateway_agent main.go
root@ip-172-31-15-208:/home/ubuntu/fornax/cloud/cmd/inter_cluster_gateway# ls
gateway_agent  gateway_config.json  main.go
```
The gateway_agent  has been built successfully

#### Step 3
Create a gateway_config.json for gateway agents
As we know in step 1, the cluster A's gateway host ip is 172.31.15.208 and the cluster B's gateway host ip is 172.31.15.238
In the configuration file in cluster A bellow
```
root@ip-172-31-15-208:/home/ubuntu/fornax/cloud/cmd/inter_cluster_gateway# cat gateway_config.json
{
    "RemoteGateways": [
        {
            "RemoteGatewayIP": "172.31.15.238",
            "RemoteGatewayPort": 2615
        }
    ],
    "GenevePort": 6081,
    "LocalDividerIP": "172.31.15.85",
    "LogLevel": "3"
}
```
For RemoteGatewayIP, it is the cluster B's gateway host ip 172.31.15.238. 
To get a LocalDividerIP, run the following command in cluster A to get the vpc1 divider ip.
```
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get dividers
NAME                                          VPC    IP             MAC                 DROPLET           STATUS        CREATETIME                   PROVISIONDELAY
vpc0-d-f3a537ab-6719-4ab5-b270-42fedf6fae59   vpc0   172.31.4.20    0a:35:42:e8:d1:e9   ip-172-31-4-20    Provisioned   2022-01-25T20:44:22.419213   0.497085
vpc1-d-6ac349e1-12c4-4d08-b6bb-c236b22a78ea   vpc1   172.31.15.85   0a:a7:d2:0e:4b:bb   ip-172-31-15-85   Provisioned   2022-01-25T20:44:46.738402   0.235793
```
Repeat the same steps in cluster B.

#### Step 4
Running gateway agents in cluster A and cluster B.
We get the agent binaries in step 2 and the  config files in step3.  Put all the files in the same directory and run ./gateway_agent

#### Step 5
Deploy pods across clusters
In cluster A, create a yaml below and apply it to create a pod pod-in-net2
```
apiVersion: v1
kind: Pod
metadata:
  name: pod-in-net2
  annotations:
    mizar.com/vpc: vpc1
    mizar.com/subnet: net2
spec:
  containers:
  - name: vanilla-container
    image: mizarnet/testpod:latest
```
Verify it has been created successfully.
```
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get pods pod-in-net2 -o wide
NAME          READY   STATUS    RESTARTS   AGE   IP              NODE             NOMINATED NODE   READINESS GATES
pod-in-net2   1/1     Running   0          29h   192.168.122.5   ip-172-31-4-20   <none>           <none>
```
In cluster B, create a yaml below and apply it to create a pod pod-in-net1
```
apiVersion: v1
kind: Pod
metadata:
  name: pod-in-net1
  annotations:
    mizar.com/vpc: vpc1
    mizar.com/subnet: net1
spec:
  containers:
  - name: vanilla-container
    image: mizarnet/testpod:latest
```
Verify it has been created successfully.
```
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl get pods pod-in-net1 -o wide
NAME          READY   STATUS    RESTARTS   AGE   IP            NODE              NOMINATED NODE   READINESS GATES
pod-in-net1   1/1     Running   0          29h   192.168.0.6   ip-172-31-11-12   <none>           <none>
```
#### Step 6
Ping pods across clusters
In cluster A, we ping the pod ip in cluster B 192.168.0.6 and it works
```
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl exec -it pod-in-net2 -- bin/ping 192.168.0.6
PING 192.168.0.6 (192.168.0.6) 56(84) bytes of data.
64 bytes from 192.168.0.6: icmp_seq=1 ttl=64 time=0.545 ms
64 bytes from 192.168.0.6: icmp_seq=2 ttl=64 time=0.439 ms
64 bytes from 192.168.0.6: icmp_seq=3 ttl=64 time=0.468 ms
64 bytes from 192.168.0.6: icmp_seq=4 ttl=64 time=0.500 ms
64 bytes from 192.168.0.6: icmp_seq=5 ttl=64 time=0.517 ms
64 bytes from 192.168.0.6: icmp_seq=6 ttl=64 time=0.492 ms
```
In cluster B, we ping the pod ip in cluster A 192.168.122.5 and it works
```
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl exec -it pod-in-net1 -- bin/ping 192.168.122.5
PING 192.168.122.5 (192.168.122.5) 56(84) bytes of data.
64 bytes from 192.168.122.5: icmp_seq=1 ttl=64 time=0.463 ms
64 bytes from 192.168.122.5: icmp_seq=2 ttl=64 time=0.549 ms
64 bytes from 192.168.122.5: icmp_seq=3 ttl=64 time=0.537 ms
64 bytes from 192.168.122.5: icmp_seq=4 ttl=64 time=0.656 ms
64 bytes from 192.168.122.5: icmp_seq=5 ttl=64 time=0.576 ms
64 bytes from 192.168.122.5: icmp_seq=6 ttl=64 time=0.606 ms
```
Try an unexisted ip and it does not work
```
root@ip-172-31-7-100:~/mizar_cluster_scripts# kubectl exec -it pod-in-net1 -- bin/ping 192.168.122.6
PING 192.168.122.6 (192.168.122.6) 56(84) bytes of data.
```


