### PR TITLE
Fixed some issues and added log enhancements

### DIFF
--- a/cloud/cmd/inter_cluster_gateway/watcher/watchers.go
+++ b/cloud/cmd/inter_cluster_gateway/watcher/watchers.go
@@ -163,7 +163,8 @@ type KubeWatcher struct {
 	dividerMap               map[*net.IPNet]NextHopAddr
 	vpcMap                   map[string]*vpcv1.Vpc
 	vpcGatewayMap            map[string]GatewayConfig
-	gatewayMap               map[string]string
+	gatewayMap               map[string]string   //for neighbors
+	remoteVpcIPMap           map[string][]string //for subnets
 	subnetGatewayMap         map[*net.IPNet]NextHopAddr
 	subnetInterface          subnetinterface.SubnetInterface
 	gatewayName              string
@@ -215,16 +216,30 @@ func NewKubeWatcher(kubeConfig *rest.Config, client *srv.Client, packetWatcher *
 		return nil, err
 	}
 	gatewayMap := make(map[string]string)
+	remoteVpcIPMap := make(map[string][]string)
 	var subGatewayMap map[*net.IPNet]NextHopAddr
 	var gatewayInfo *v1.ConfigMap
 	if gatewayInfo, err = gatewayconfigmapclientset.CoreV1().ConfigMaps("default").Get(context.TODO(), constants.ClusterGatewayConfigMap, metav1.GetOptions{}); err == nil {
-		if gateways := gatewayInfo.Data[constants.ClusterGatewayConfigMapVpcGateways]; gateways != "" {
+		if gateways := gatewayInfo.Data[constants.ClusterGatewayConfigMapGatewayNeighbors]; gateways != "" {
 			gatewayArr := strings.Split(gateways, ",")
 			for _, gatewayPair := range gatewayArr {
 				gateway := strings.Split(gatewayPair, "=")
 				gatewayMap[gateway[0]] = gateway[1]
 			}
 		}
+		if remoteVpcIPs := gatewayInfo.Data[constants.ClusterGatewayConfigMapVpcGateways]; remoteVpcIPs != "" {
+			remoteVpcIPArr := strings.Split(remoteVpcIPs, ",")
+			for _, vpcIPPair := range remoteVpcIPArr {
+				vpcIP := strings.Split(vpcIPPair, "=")
+				if IPList, ok := remoteVpcIPMap[vpcIP[0]]; ok {
+					IPList = append(IPList, vpcIP[1])
+					remoteVpcIPMap[vpcIP[0]] = IPList
+				} else {
+					remoteVpcIPMap[vpcIP[0]] = []string{vpcIP[1]}
+				}
+			}
+		}
+		klog.V(3).Infof("The current remoteVpcIPMap is %v", remoteVpcIPMap)
 		if subGateways := gatewayInfo.Data[constants.ClusterGatewayConfigMapSubGateways]; subGateways != "" {
 			subGatewayMap = getSubnetGatewayMap(subGateways, subMap, packetWatcher)
 		}
@@ -271,6 +286,7 @@ func NewKubeWatcher(kubeConfig *rest.Config, client *srv.Client, packetWatcher *
 		vpcGatewayMap:            make(map[string]GatewayConfig),
 		subnetGatewayMap:         subGatewayMap,
 		gatewayMap:               gatewayMap,
+		remoteVpcIPMap:           remoteVpcIPMap,
 		subnetInterface:          subnetclientset.MizarV1().Subnets("default"),
 		client:                   client,
 		packetWatcher:            packetWatcher,
@@ -290,7 +306,19 @@ func (watcher *KubeWatcher) Run() {
 					gateway := strings.Split(gatewayPair, "=")
 					watcher.gatewayMap[gateway[0]] = gateway[1]
 				}
-				klog.V(3).Infof("the gateway map is set to %v", watcher.gatewayMap)
+				if remoteVpcIPs := cm.Data[constants.ClusterGatewayConfigMapVpcGateways]; remoteVpcIPs != "" {
+					remoteVpcIPArr := strings.Split(remoteVpcIPs, ",")
+					for _, vpcIPPair := range remoteVpcIPArr {
+						vpcIP := strings.Split(vpcIPPair, "=")
+						if IPList, ok := watcher.remoteVpcIPMap[vpcIP[0]]; ok {
+							IPList = append(IPList, vpcIP[1])
+							watcher.remoteVpcIPMap[vpcIP[0]] = IPList
+						} else {
+							watcher.remoteVpcIPMap[vpcIP[0]] = []string{vpcIP[1]}
+						}
+					}
+				}
+				klog.V(3).Infof("the remote vpc ip map is set to %v", watcher.remoteVpcIPMap)
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
@@ -304,6 +332,24 @@ func (watcher *KubeWatcher) Run() {
 					watcher.gatewayMap[gateway[0]] = gateway[1]
 				}
 				klog.V(3).Infof("the gateway map is updated to %v", watcher.gatewayMap)
+			}
+			// Updated the remote vpc gateway ips
+			if oldCm.Data[constants.ClusterGatewayConfigMapVpcGateways] != newCm.Data[constants.ClusterGatewayConfigMapVpcGateways] {
+				if remoteVpcIPs := newCm.Data[constants.ClusterGatewayConfigMapVpcGateways]; remoteVpcIPs != "" {
+					remoteVpcIPArr := strings.Split(remoteVpcIPs, ",")
+					for _, vpcIPPair := range remoteVpcIPArr {
+						vpcIP := strings.Split(vpcIPPair, "=")
+						if IPList, ok := watcher.remoteVpcIPMap[vpcIP[0]]; ok {
+							IPList = append(IPList, vpcIP[1])
+							watcher.remoteVpcIPMap[vpcIP[0]] = IPList
+						} else {
+							watcher.remoteVpcIPMap[vpcIP[0]] = []string{vpcIP[1]}
+						}
+					}
+				} else {
+					watcher.remoteVpcIPMap = make(map[string][]string)
+				}
+				klog.V(3).Infof("the remote vpc ip map is updated to to %v", watcher.remoteVpcIPMap)
 			}
 			// Updated the vpc gateway info
 			klog.V(3).Infof("a new vpc is created/deleted in a neighbor and the vpc gateway pair is updated from %s to %s",
@@ -345,22 +391,24 @@ func (watcher *KubeWatcher) Run() {
 			if subnet, ok := obj.(*subnetv1.Subnet); ok {
 				klog.V(3).Infof("a new subnet %s is created", subnet.Name)
 				if !subnet.Spec.Virtual {
-					for gatewayName, gatewayHostIP := range watcher.gatewayMap {
-						klog.V(3).Infof("a new subnet %s is trying to sync to %s with the ip %s", subnet.Name, gatewayName, gatewayHostIP)
-						conn, client, ctx, cancel, err := watcher.client.Connect(gatewayHostIP)
-						if err != nil {
-							klog.Errorf("failed to sync a new subnet to %s with the error %v", gatewayHostIP, err)
-						}
-						defer conn.Close()
-						defer cancel()
-						request := &proto.CreateSubnetRequest{
-							Name: subnet.Name, Namespace: subnet.Namespace, IP: subnet.Spec.IP, Status: subnet.Spec.Status,
-							Prefix: subnet.Spec.Prefix, Vpc: subnet.Spec.Vpc, Vni: subnet.Spec.Vni, RemoteGateway: watcher.gatewayHostIP,
-							Bouncers: int32(subnet.Spec.Bouncers)}
-						returnMessage, err := client.CreateSubnet(ctx, request)
-						klog.V(3).Infof("the returnMessage is %v", returnMessage)
-						if err != nil {
-							klog.Errorf("return from %s with the message %v with the error %v", gatewayHostIP, returnMessage, err)
+					if remoteVpcIPList, ok := watcher.remoteVpcIPMap[subnet.Spec.Vpc]; ok {
+						for _, remoteVpcIP := range remoteVpcIPList {
+							klog.V(3).Infof("a new subnet %s is trying to sync to a remote vpc %s with the ip %s", subnet.Name, subnet.Spec.Vpc, remoteVpcIP)
+							conn, client, ctx, cancel, err := watcher.client.Connect(remoteVpcIP)
+							if err != nil {
+								klog.Errorf("failed to sync a new subnet to %s with the error %v", remoteVpcIP, err)
+							}
+							defer conn.Close()
+							defer cancel()
+							request := &proto.CreateSubnetRequest{
+								Name: subnet.Name, Namespace: subnet.Namespace, IP: subnet.Spec.IP, Status: subnet.Spec.Status,
+								Prefix: subnet.Spec.Prefix, Vpc: subnet.Spec.Vpc, Vni: subnet.Spec.Vni, RemoteGateway: watcher.gatewayHostIP,
+								Bouncers: int32(subnet.Spec.Bouncers)}
+							returnMessage, err := client.CreateSubnet(ctx, request)
+							klog.V(3).Infof("the returnMessage is %v", returnMessage)
+							if err != nil {
+								klog.Errorf("return from %s with the message %v with the error %v", remoteVpcIP, returnMessage, err)
+							}
 						}
 					}
 				}
@@ -370,20 +418,22 @@ func (watcher *KubeWatcher) Run() {
 			if subnet, ok := obj.(*subnetv1.Subnet); ok {
 				klog.V(3).Infof("a new subnet %s is deleted", subnet.Name)
 				if !subnet.Spec.Virtual {
-					for gatewayName, gatewayHostIP := range watcher.gatewayMap {
-						klog.V(3).Infof("a deleted subnet %s is trying to sync to %s with the ip %s", subnet.Name, gatewayName, gatewayHostIP)
-						conn, client, ctx, cancel, err := watcher.client.Connect(gatewayHostIP)
-						if err != nil {
-							klog.Errorf("failed to sync a deleted subnet to %s with the error %v", gatewayHostIP, err)
-						}
-						defer conn.Close()
-						defer cancel()
-						request := &proto.DeleteSubnetRequest{
-							Name: subnet.Name, Namespace: subnet.Namespace}
-						returnMessage, err := client.DeleteSubnet(ctx, request)
-						klog.V(3).Infof("The returnMessage is %v", returnMessage)
-						if err != nil {
-							klog.Errorf("return from %s with the message %v with the error %v", gatewayHostIP, returnMessage, err)
+					if remoteVpcIPList, ok := watcher.remoteVpcIPMap[subnet.Spec.Vpc]; ok {
+						for _, remoteVpcIP := range remoteVpcIPList {
+							klog.V(3).Infof("a deleted subnet %s is trying to sync to a remote vpc %s with the ip %s", subnet.Name, subnet.Spec.Vpc, remoteVpcIP)
+							conn, client, ctx, cancel, err := watcher.client.Connect(remoteVpcIP)
+							if err != nil {
+								klog.Errorf("failed to sync a new subnet to %s with the error %v", remoteVpcIP, err)
+							}
+							defer conn.Close()
+							defer cancel()
+							request := &proto.DeleteSubnetRequest{
+								Name: subnet.Name, Namespace: subnet.Namespace}
+							returnMessage, err := client.DeleteSubnet(ctx, request)
+							klog.V(3).Infof("the returnMessage is %v", returnMessage)
+							if err != nil {
+								klog.Errorf("return from %s with the message %v with the error %v", remoteVpcIP, returnMessage, err)
+							}
 						}
 					}
 				}

--- a/cloud/pkg/edgecontroller/manager/configmap.go
+++ b/cloud/pkg/edgecontroller/manager/configmap.go
@@ -1,6 +1,9 @@
 package manager
 
 import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -9,7 +12,8 @@ import (
 
 // ConfigMapManager manage all events of configmap by SharedInformer
 type ConfigMapManager struct {
-	events chan watch.Event
+	events     chan watch.Event
+	configMaps sync.Map
 }
 
 // Events return the channel save events from watch configmap change
@@ -24,4 +28,22 @@ func NewConfigMapManager(si cache.SharedIndexInformer) (*ConfigMapManager, error
 	si.AddEventHandler(rh)
 
 	return &ConfigMapManager{events: events}, nil
+}
+
+// AddOrUpdateConfigMap is to maintain the configMapin the cache up-to-date
+func (cmm *ConfigMapManager) AddOrUpdateConfigMap(cm *v1.ConfigMap) {
+	cmm.configMaps.Store(cm.Name, cm)
+}
+
+// Delete ConfigMap from cache
+func (cmm *ConfigMapManager) DeleteConfigMap(cmName string) {
+	cmm.configMaps.Delete(cmName)
+}
+
+// Get ConfigMap from cache
+func (cmm *ConfigMapManager) GetConfigMap(cmName string) *v1.ConfigMap {
+	if value, ok := cmm.configMaps.Load(cmName); ok {
+		return value.(*v1.ConfigMap)
+	}
+	return nil
 }

--- a/cloud/pkg/edgecontroller/manager/configmap_test.go
+++ b/cloud/pkg/edgecontroller/manager/configmap_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -100,6 +102,127 @@ func TestNewConfigMapManager(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			NewConfigMapManager(tt.args.informer)
+		})
+	}
+}
+
+func TestAddOrUpdateConfigMaps(t *testing.T) {
+	ch := make(chan watch.Event, 1)
+	tests := []struct {
+		name  string
+		input *corev1.ConfigMap
+	}{
+		{
+			"AddOrUpdateConfigMap Case 1",
+			&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cluster-gateway-config",
+					Namespace:       "default",
+					ResourceVersion: "1",
+					UID:             "0387947d-d637-4f92-965d-11b8bdc9f548",
+				},
+				Data: map[string]string{
+					"gateway_host_ip": "172.31.11.31",
+					"gateway_name":    "edge_gateway",
+				},
+				BinaryData: map[string][]byte{},
+			},
+		},
+		{
+			"AddOrUpdateConfigMap Case 2",
+			&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cluster-gateway-config",
+					Namespace:       "default",
+					ResourceVersion: "2",
+				},
+				Data: map[string]string{
+					"gateway_host_ip":   "127.0.0.1",
+					"gateway_name":      "edge_gateway",
+					"gateway_neighbors": "edge1_gateway=172.31.11.31,edge2-gateway=172.31.9.254",
+				},
+				BinaryData: map[string][]byte{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmm := &ConfigMapManager{
+				events: ch,
+			}
+			cmm.AddOrUpdateConfigMap(test.input)
+			if got := cmm.GetConfigMap(test.input.Name); !reflect.DeepEqual(got, test.input) {
+				t.Errorf("ConfigMapManager.AddOrUpdateConfigMap() = %v, want %v", got, test.input)
+			}
+		})
+	}
+}
+
+func TestDeleteConfigMaps(t *testing.T) {
+	ch := make(chan watch.Event, 1)
+	tests := []struct {
+		name  string
+		input *corev1.ConfigMap
+	}{
+		{
+			"TestDeleteConfigMaps Case 1",
+			&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cluster-gateway-config1",
+					Namespace:       "default",
+					ResourceVersion: "1",
+					UID:             "0387947d-d637-4f92-965d-11b8bdc9f548",
+				},
+				Data: map[string]string{
+					"gateway_host_ip": "172.31.11.31",
+					"gateway_name":    "edge_gateway",
+				},
+				BinaryData: map[string][]byte{},
+			},
+		},
+		{
+			"TestDeleteConfigMaps Case 2",
+			&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cluster-gateway-config2",
+					Namespace:       "default",
+					ResourceVersion: "2",
+				},
+				Data: map[string]string{
+					"gateway_host_ip":   "127.0.0.1",
+					"gateway_name":      "edge_gateway",
+					"gateway_neighbors": "edge1_gateway=172.31.11.31,edge2-gateway=172.31.9.254",
+				},
+				BinaryData: map[string][]byte{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmm := &ConfigMapManager{
+				events: ch,
+			}
+			cmm.AddOrUpdateConfigMap(test.input)
+			cmm.DeleteConfigMap(test.input.Name)
+			if got := cmm.GetConfigMap(test.input.Name); got != nil {
+				t.Errorf("ConfigMapManager.DeleteConfigMap() failed to delete the configmap %s", got.Name)
+			}
 		})
 	}
 }

--- a/edge/pkg/metamanager/client/configmap.go
+++ b/edge/pkg/metamanager/client/configmap.go
@@ -7,6 +7,7 @@ import (
 	api "k8s.io/api/core/v1"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
@@ -43,7 +44,7 @@ func (c *configMaps) Create(cm *api.ConfigMap) (*api.ConfigMap, error) {
 }
 
 func (c *configMaps) Update(cm *api.ConfigMap) error {
-	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeConfigmap, cm.ClusterName)
+	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeConfigmap, constants.ClusterGatewayConfigMap)
 	configMapsMsg := message.BuildMsg(modules.MetaGroup, "", modules.ClusterdModuleName, resource, model.UpdateOperation, cm)
 	_, err := c.send.SendSync(configMapsMsg)
 	if err != nil {


### PR DESCRIPTION
The PR is to check adding edge clusters to cloud can update the edge cluster configmap by adding neighbors

Running cloudcore in cloud
```bash
export KUBECONFIG=/etc/kubernetes/admin.conf
nohup _output/local/bin/cloudcore >> cloudcore.logs 2>&1 & 
```
Running edgecore in a newly added cluster
```bash
export KUBECONFIG=/etc/kubernetes/admin.conf
nohup _output/local/bin/edgecore --edgecluster >> edgecore.logs 2>&1 &
```
Verify that the edge cluster has been added in cloud
```bash
root@cloud-master:/home/ubuntu/go/src/github.com/fornax# tail -f cloudcore.logs 
I0420 20:29:08.935223   20003 signcerts.go:100] Succeed to creating token
I0420 20:29:08.935287   20003 server.go:44] start unix domain socket server
I0420 20:29:08.935846   20003 uds.go:71] listening on: //var/lib/kubeedge/kubeedge.sock
I0420 20:29:08.936043   20003 server.go:64] Starting cloudhub websocket server
I0420 20:29:10.813686   20003 upstream.go:63] Start upstream devicecontroller
I0420 20:29:28.819999   20003 messagehandler.go:293] edge node edge1-master for project e632aba927ea4ac2b575ec1603d56f10 connected
```

Verify that the configmap has been updated in cloud
```bash
root@cloud-master:~/go/src/github.com/fornax# kubectl get configmap cluster-gateway-config -o json
{
    "apiVersion": "v1",
    "data": {
        "gateway_host_ip": "172.31.14.243",
        "gateway_name": "cloud_gateway",
        "gateway_neighbors": "edge1_gateway=172.31.11.31"
    },
    "kind": "ConfigMap",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"gateway_host_ip\":\"172.31.14.243\",\"gateway_name\":\"cloud_gateway\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"cluster-gateway-config\",\"namespace\":\"default\"}}\n"
        },
        "creationTimestamp": "2022-04-20T20:01:20Z",
        "name": "cluster-gateway-config",
        "namespace": "default",
        "resourceVersion": "3265",
        "uid": "2e23fa5a-a0f1-4606-ad5a-9a80b9d18693"
    }
}

```

Verify that the configmap has been updated in the edge cluster
```bash
root@edge1-master:~/go/src/github.com/fornax# kubectl get configmap  cluster-gateway-config -o json
{
    "apiVersion": "v1",
    "data": {
        "gateway_host_ip": "172.31.11.31",
        "gateway_name": "edge1_gateway",
        "gateway_neighbors": "cloud_gateway=172.31.14.243"
    },
    "kind": "ConfigMap",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"gateway_host_ip\":\"172.31.11.31\",\"gateway_name\":\"edge1_gateway\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"cluster-gateway-config\",\"namespace\":\"default\"}}\n"
        },
        "creationTimestamp": "2022-04-20T19:23:51Z",
        "name": "cluster-gateway-config",
        "namespace": "default",
        "resourceVersion": "58750",
        "uid": "0387947d-d637-4f92-965d-11b8bdc9f548"
    }
}

```

